### PR TITLE
gene and aachange parameters

### DIFF
--- a/BEACON-V2-draft4-Model/genomicVariations/endpoints.json
+++ b/BEACON-V2-draft4-Model/genomicVariations/endpoints.json
@@ -21,7 +21,9 @@
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
           { "$ref": "#/components/parameters/includeResultsetResponses" },
-          { "$ref": "#/components/parameters/genomicAlleleShortForm" }
+          { "$ref": "#/components/parameters/genomicAlleleShortForm" },
+          { "$ref": "#/components/parameters/gene" },
+          { "$ref": "#/components/parameters/aaChange" }
         ],
         "description": "Get a list of example entries",
         "operationId": "getExampleEntries",
@@ -298,6 +300,22 @@
           "type": "string"
         },
         "example": "NM_004006.2:c.4375C>T"
+      },
+      "gene": {
+        "name": "gene",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "example": "BRAF"
+      },
+      "aaChange": {
+        "name": "aachange",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "example": "V600E"
       }
     }
   }

--- a/BEACON-V2-draft4-Model/genomicVariations/requestParameters.json
+++ b/BEACON-V2-draft4-Model/genomicVariations/requestParameters.json
@@ -59,6 +59,16 @@
       },
       "mateName": {
         "$ref": "./requestParametersComponents.json#/definitions/RefSeqId"
+      },
+      "gene": {
+        "description": "Gene symbol following the HGNC (https://www.genenames.org) nomenclature.",
+        "type": "string",
+        "examples": ["BRAF", "SCN5A"]
+      },
+      "aachange": {
+        "description": "Aminoacid substitution of interest. Format 1 letter ",
+        "type": "string",
+        "examples": ["V600E", "M734V"]
       }
     }
   }


### PR DESCRIPTION
So far, we have been looking at Beacon from the genomic allele point of view, but we are having more and more examples of queries based on gene name/symbol and aminoacid substitution. 
This is in our slide with examples, in the Matchmaker Exchange requests and probably in many rare diseases and oncology use cases.
Although the gene name could be addressed by the filtering terms, no so with the aa-change...
I've realized that adding both aspects as "named parameters" could make the solution much more straight-forward and, hence, I'm suggesting adding these two parameters in this PR.