### PR TITLE
updating pedigree allowing foreing individuals

### DIFF
--- a/BEACON-V2-draft4-Model/common/pedigree.json
+++ b/BEACON-V2-draft4-Model/common/pedigree.json
@@ -12,26 +12,82 @@
     "disease": {
       "$ref": "../common/disease.json"
     },
-    "role": {
-      "description": "Pedigree role, defined as relationship to proband. Value from Family Member term (NCIT:C41256), e.g. \"proband\" (NCIT:C64435),\"identical twin\" (NCIT:C73429), \"mother\" (NCIT:C25189).",
-      "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
-      "examples": [
-        { "id": "NCIT:C64435", "label": "Proband" },
-        { "id": "NCIT:C96580", "label": "Biological Mother" },
-        { "id": "NCIT:C96572", "label": "Biological Father" },
-        { "id": "NCIT:C165848", "label": "Identical Twin Brother" }
-      ]
-    },
-    "affected": {
-      "description": "Affected status of Individual in disease of pedigree.",
-      "type": "boolean"
-    },
     "numSubjects": {
       "description": "Total number of subjects in pedigree.",
       "type": "integer",
       "example": 10
+    },
+    "members": {
+      "type": "array",
+      "description": "List of members of the pedigree. If the current pedigree definition is attached to the proband, it contains the whole list of pedigree members, including the proband. If the definition is attached to an individual different than the proband, it only contains two entries: one that describes that member, e.g. the proband mother or father, and one that points to the proband.",
+      "items": {
+        "$ref": "#/definitions/pedigreeMember"
+      },
+      "minItems": 1
     }
   },
-  "required": ["id", "role", "affected"],
+  "definitions": {
+    "pedigreeMember": {
+      "type": "object",
+      "properties": {
+        "memberId": {
+          "description": "Identifier of the individual. The individual could be part of the same Beacon datasets or not, in which case the information here is meant to complete the pedigree. If the individual is also in the dataset use that Individual ID. If it is not the in the dataset, use a non-collading ID, e.g. concatenating the Pedigree ID with a local ID, similarly to the example 'Pedigree1001-m1'.",
+          "type": "string",
+          "examples": ["Pedigree1001-m1", "Ind0012122"]
+        },
+        "role": {
+          "description": "Pedigree role, defined as relationship to proband. Value from Family Member term (NCIT:C41256), e.g. \"proband\" (NCIT:C64435),\"identical twin\" (NCIT:C73429), \"mother\" (NCIT:C25189).",
+          "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
+          "examples": [
+            { "id": "NCIT:C64435", "label": "Proband" },
+            { "id": "NCIT:C96580", "label": "Biological Mother" },
+            { "id": "NCIT:C96572", "label": "Biological Father" },
+            { "id": "NCIT:C165848", "label": "Identical Twin Brother" }
+          ]
+        },
+        "affected": {
+          "description": "Is the individual affected by the disease in the pedigree?",
+          "type": "boolean"
+        }
+      },
+      "examples": [
+        {
+          "membersInProband": [
+            {
+              "memberId": "Ind0012122",
+              "role": { "id": "NCIT:C64435", "label": "Proband" },
+              "affected": true
+            },
+            {
+              "memberId": "Pedigree1001-m2",
+              "role": { "id": "NCIT:C96580", "label": "Biological Mother" },
+              "affected": false
+            },
+            {
+              "memberId": "Pedigree1001-m3",
+              "role": { "id": "NCIT:C96572", "label": "Biological Father" },
+              "affected": true
+            }
+          ]
+        },
+        {
+          "membersInMother": [
+            {
+              "memberId": "Ind0028989",
+              "role": { "id": "NCIT:C96580", "label": "Biological Mother" },
+              "affected": false
+            },
+            {
+              "memberId": "Ind0012122",
+              "role": { "id": "NCIT:C64435", "label": "Proband" },
+              "affected": true
+            }
+          ]
+        }
+      ],
+      "required": ["memberId", "role", "affected"]
+    }
+  },
+  "required": ["id", "disease", "members"],
   "additionalProperties": true
 }

--- a/BEACON-V2-draft4-Model/individuals/examples/individual-with-pedigree-MID-example.json
+++ b/BEACON-V2-draft4-Model/individuals/examples/individual-with-pedigree-MID-example.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "../defaultSchema.json",
+  "id": "Ind001",
+  "sex": {
+    "id": "NCIT:C16576",
+    "label": "female"
+  },
+  "ethnicity": {
+    "id": "NCIT:C43851",
+    "label": "European"
+  },
+  "geographicOrigin": {
+    "id": "GAZ:00002586",
+    "label": "State of Wisconsin"
+  },
+  "diseases": [
+    {
+      "diseaseCode": {
+        "id": "HP:0001645",
+        "label": "Sudden cardiac death"
+      },
+      "ageOfOnset": {
+        "ageGroup": {
+          "id": "NCIT:C16731",
+          "label": "Newborn"
+        }
+      },
+      "familyHistory": true,
+      "severityLevel": {
+        "id": "HP:0012828",
+        "label": "Severe"
+      }
+    }
+  ],
+  "pedigrees": [
+    {
+      "id": "SCD-Pedigree001",
+      "disease": {
+        "diseaseCode": {
+          "id": "HP:0001645",
+          "label": "Sudden cardiac death"
+        }
+      },
+      "numSubjects": 4,
+      "members": [
+        {
+          "memberId": "Ind001",
+          "role": { "id": "NCIT:C64435", "label": "Proband" },
+          "affected": true
+        },
+        {
+          "memberId": "Ind011",
+          "role": {
+            "id": "NCIT:C96572",
+            "label": "Biological Father"
+          },
+          "affected": false
+        },
+        {
+          "memberId": "Ind012",
+          "role": { "id": "NCIT:C96572", "label": "Biological Father" },
+          "affected": false
+        },
+        {
+          "memberId": "Ind022",
+          "role": {
+            "id": "NCIT:C111201",
+            "label": "Full Brother"
+          },
+          "affected": false
+        }
+      ]
+    }
+  ]
+}

--- a/BEACON-V2-draft4-Model/individuals/examples/pedigree-example.json
+++ b/BEACON-V2-draft4-Model/individuals/examples/pedigree-example.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "../../common/pedigree.json",
+  "id": "SCD-Pedigree001",
+  "disease": {
+    "diseaseCode": {
+      "id": "HP:0004789",
+      "label": "lactose intolerance"
+    }
+  },
+  "numSubjects": 4,
+  "members": [
+    {
+      "memberId": "Ind001",
+      "role": { "id": "NCIT:C64435", "label": "Proband" },
+      "affected": true
+    },
+    {
+      "memberId": "Pedigree1001-m1",
+      "role": {
+        "id": "NCIT:C96572",
+        "label": "Biological Father"
+      },
+      "affected": false
+    },
+    {
+      "memberId": "Pedigree1001-m3",
+      "role": { "id": "NCIT:C96572", "label": "Biological Father" },
+      "affected": false
+    },
+    {
+      "memberId": "Pedigree1001-m2",
+      "role": {
+        "id": "NCIT:C111201",
+        "label": "Full Brother"
+      },
+      "affected": false
+    }
+  ]
+}


### PR DESCRIPTION
The current pedigree model makes sense when all individuals in the pedigree are also individuals in the dataset, but doesn't allow to mention individuals that are not part of it.
Example: We have a family w. mother, father, proband and sister. 

- If all of them have been sequenced or have a clinical record, and thus we have all of them as individuals in the dataset, the current model fits.
- If we have not sequenced or registered the sister, as she is not in a proper individual in the dataset, we have no place to register that a sister exists and if she is affected by the disease or not.

This PR is extending the model to support information for individuals that are not part of the dataset.