### PR TITLE
Converting relative paths to URLs

### DIFF
--- a/BEACON-V2-draft4-Model/beaconConfiguration.json
+++ b/BEACON-V2-draft4-Model/beaconConfiguration.json
@@ -21,7 +21,7 @@
       "defaultSchema": {
         "id": "ga4gh-beacon-dataset-v2.0.0-draft.4",
         "name": "Default schema for datasets",
-        "referenceToSchemaDefinition": "./datasets/defaultSchema.json",
+        "referenceToSchemaDefinition": "https://exampleBeacons.org/datasets/defaultSchema.json",
         "schemaVersion": "v2.0.0-draft.4"
       },
       "aCollectionOf": [{ "id": "genomicVariant", "name": "Genomic Variants" }],
@@ -39,7 +39,7 @@
       "defaultSchema": {
         "id": "ga4gh-beacon-cohort-v2.0.0-draft.4",
         "name": "Default schema for cohorts",
-        "referenceToSchemaDefinition": "./cohorts/defaultSchema.json",
+        "referenceToSchemaDefinition": "https://exampleBeacons.org/cohorts/defaultSchema.json",
         "schemaVersion": "v2.0.0-draft.4"
       },
       "aCollectionOf": [{ "id": "individual", "name": "Individuals" }],
@@ -57,7 +57,7 @@
       "defaultSchema": {
         "id": "ga4gh-beacon-variant-v2.0.0-draft.4",
         "name": "Default schema for a genomic variation",
-        "referenceToSchemaDefinition": "./genomicVariations/defaultSchema.json",
+        "referenceToSchemaDefinition": "https://exampleBeacons.org/genomicVariations/defaultSchema.json",
         "schemaVersion": "v2.0.0-draft.4"
       },
       "additionallySupportedSchemas": []
@@ -74,7 +74,7 @@
       "defaultSchema": {
         "id": "ga4gh-beacon-individual-v2.0.0-draft.4",
         "name": "Default schema for an individual",
-        "referenceToSchemaDefinition": "./individuals/defaultSchema.json",
+        "referenceToSchemaDefinition": "https://exampleBeacons.org/individuals/defaultSchema.json",
         "schemaVersion": "v2.0.0-draft.4"
       },
       "additionallySupportedSchemas": []
@@ -91,7 +91,7 @@
       "defaultSchema": {
         "id": "ga4gh-beacon-biosample-v2.0.0-draft.4",
         "name": "Default schema for a biological sample",
-        "referenceToSchemaDefinition": "./biosamples/defaultSchema.json",
+        "referenceToSchemaDefinition": "https://exampleBeacons.org/biosamples/defaultSchema.json",
         "schemaVersion": "v2.0.0-draft.4"
       },
       "additionallySupportedSchemas": []
@@ -108,7 +108,7 @@
       "defaultSchema": {
         "id": "ga4gh-beacon-run-v2.0.0-draft.4",
         "name": "Default schema for a sequencing run",
-        "referenceToSchemaDefinition": "./runs/defaultSchema.json",
+        "referenceToSchemaDefinition": "https://exampleBeacons.org/runs/defaultSchema.json",
         "schemaVersion": "v2.0.0-draft.4"
       },
       "additionallySupportedSchemas": []
@@ -125,7 +125,7 @@
       "defaultSchema": {
         "id": "ga4gh-beacon-analysis-v2.0.0-draft.4",
         "name": "Default schema for a bioinformatics analysis",
-        "referenceToSchemaDefinition": "./analyses/defaultSchema.json",
+        "referenceToSchemaDefinition": "https://exampleBeacons.org/analyses/defaultSchema.json",
         "schemaVersion": "v2.0.0-draft.4"
       },
       "additionallySupportedSchemas": []


### PR DESCRIPTION
We have two open ends in the beaconConfiguration.json and beaconMap.json.
In the former, the property `referenceToSchemaDefinition` was a relative file path, which was, of course not desired.
Similarly, in the latter, we have the attribute `openAPIEndpointsDefinition` as a relative URL.
Both were left that way as I have thought we need a solution and we will simply update that later.
I've realized that as we should simply return these files as they are, nothing else than converting the path to an URL is required.
As it seems so simple to me now, I just want a couple of eyes more looking into it.

By mistake, I directly committed the changes for beaconMap already.