### PR TITLE
some fixing of descriptions in variations schema

### DIFF
--- a/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
@@ -12,22 +12,22 @@
   ],
   "properties": {
     "variantInternalId": {
-      "description": "Reference to the variant ID (internal ID). This is no a public Id, but the 'primary key/identifier' of that variant inside a given Beacon instance. Therefore, different Beacon instances could have a variantInternalId = 1 and they could refer to completely unrelated variants. The public, standard, popular identifiers or the GA4GH Variant Representation Id (VRSid) MUST be returned in the  'identifiers' section. A Beacon instance can, of course, use the VRSid as their own internal id, in such case, the VRSid would be repeated in both places.",
+      "description": "Reference to the variant ID (internal ID). This is no a public Id, but the `primary key/identifier` of that variant inside a given Beacon instance. Therefore, different Beacon instances could have a variantInternalId = 1 and they could refer to completely unrelated variants. The public, standard, popular identifiers or the GA4GH Variant Representation Id (VRSid) MUST be returned in the  `identifiers` section. A Beacon instance can, of course, use the VRSid as their own internal id, in such case, the VRSid would be repeated in both places.",
       "type": "string"
     },
     "variantType": {
-      "description": "The `variantType` declares the nature of the variation in relation to a reference. It could be a single change, a short insertion or deletion, a bigger structural change, etc. In a response, it is used to describe the variation. In a request, it is used to declare the type of event the Beacon client is looking for. It could be used standalone (without `alternateBases` parameter) in cases in which query variants could not be defined through a sequence of one or more bases. Examples here are e.g. structural variants: \n* DUP - increased allelic count of material from the genomic region  between `start` and `end` positions  - no assumption about the placement of the additional sequences is  being made (i.e. no _in situ_ requirement as tandem duplications)\n * DEL: deletion of sequence following `start` \n* BND: breakend, i.e. termination of the allele at position `start` or in the `start[0]]` => `start[1]` interval, or fusion of the sequence to distant partner.\n Either `alternateBases` or `variantType` is required, with the exception of range queries (single `start` and `end` parameters).",
+      "description": "The `variantType` declares the nature of the variation in relation to a reference sequence at the indicated position. In a response, it is used to describe the variation. In a request, it is used to declare the type of event(s) the Beacon client is looking for. `variantType` can be used without an `alternateBases` parameter in cases in which query variants could not be defined through a sequence of one or more bases. Examples here are e.g. structural variants: DUP - increased allelic count of material from the genomic region  between `start` and `end` positions; DEL: deletion of sequence following `start`; or BND: breakend, i.e. termination of the allele at position `start` or in the `start[0]` => `start[1]` interval, or fusion of the sequence at this position to distant partner. Either `alternateBases` or `variantType` is required, with the exception of range queries (single `start` and `end` parameters).",
       "type": "string",
       "examples": ["SNP", "DEL", "DUP", "BND"],
       "default": "SNP"
     },
     "referenceBases": {
-      "description": "Reference bases for this variant (starting from `start`). * Accepted values: IUPAC codes for nucleotides (e.g. 'https://www.bioinformatics.org/sms/iupac.html'). N is a wildcard, that denotes the position of any base, and can be used as a standalone base of any type or within a partially known sequence. As example, a query of `ANNT` the Ns can take take any form of [ACGT] and will match `ANNT`, `ACNT`, `ACCT`, `ACGT` ... and so forth. * an *empty value* is used in the case of insertions with the maximally trimmed, inserted sequence being indicated in `AlternateBases`. NOTE: Many Beacon instances could not support UIPAC codes and it is not mandatory for them to do so. In such cases the [ACGTN] is mand",
+      "description": "Reference bases for this variant (starting from `start`). * Accepted values: IUPAC codes for nucleotides (e.g. `https://www.bioinformatics.org/sms/iupac.html`). N is a wildcard, that denotes the position of any base, and can be used as a standalone base of any type or within a partially known sequence. As example, a query of `ANNT` the Ns can take take any form of [ACGT] and will match `ANNT`, `ACNT`, `ACCT`, `ACGT` ... and so forth. * an *empty value* is used in the case of insertions with the maximally trimmed, inserted sequence being indicated in `AlternateBases`. NOTE: Many Beacon instances could not support UIPAC codes and it is not mandatory for them to do so. In such cases the use of [ACGTN] is mandated.",
       "type": "string",
       "pattern": "^([ACGTUNRYSWKMBDHV\\-\\.]*)$"
     },
     "alternateBases": {
-      "description": "Alternate bases for this variant (starting from `start`).* Accepted values: IUPAC codes for nucleotides (e.g. 'https://www.bioinformatics.org/sms/iupac.html'). N is a wildcard, that denotes the position of any base, and can beused as a standalone base of any type or within a partially knownsequence. As example, a query of `ANNT` the Ns can take take any form of[ACGT] and will match `ANNT`, `ACNT`, `ACCT`, `ACGT` ... and so forth.* an *empty value* is used in the case of deletions with the maximally trimmed, deleted sequence being indicated in `ReferenceBases`* Categorical variant queries, e.g. such *not* being represented through sequence & position, make use of the `variantType` parameter.* either `alternateBases` or `variantType` is required.",
+      "description": "Alternate bases for this variant (starting from `start`). * Accepted values: IUPAC codes for nucleotides (e.g. `https://www.bioinformatics.org/sms/iupac.html`). N is a wildcard, that denotes the position of any base, and can beused as a standalone base of any type or within a partially knownsequence. As example, a query of `ANNT` the Ns can take take any form of[ACGT] and will match `ANNT`, `ACNT`, `ACCT`, `ACGT` ... and so forth.* an *empty value* is used in the case of deletions with the maximally trimmed, deleted sequence being indicated in `ReferenceBases`* Categorical variant queries, e.g. such *not* being represented through sequence & position, make use of the `variantType` parameter. * Either `alternateBases` or `variantType` is required.",
       "type": "string",
       "pattern": "^([ACGTUNRYSWKMBDHV\\-\\.]*)$"
     },
@@ -60,7 +60,7 @@
   "definitions": {
     "Position": {
       "type": "object",
-      "description": "This section groups all attributes that allows to 'identify' a variant via its position in the genome.",
+      "description": "This section groups all attributes that allows to `identify` a variant via its position in the genome.",
       "properties": {
         "assemblyId": {
           "description": "Genomic assembly accession and version as RefSqeq assembly accession (e.g. \"GCF_000001405.39\") or a versioned assembly name or synonym such as UCSC Genome Browser assembly (e.g. \"hg38\") or Genome Reference Consortium Human (e.g. \"GRCh38.p13\") names.",
@@ -181,7 +181,7 @@
           ]
         },
         "featureID": {
-          "description": "Where applicable, ID/accession/name of genomic feature related to the `featureClass`. Preferably in CURIE format. If the value is a gene id or name, it points to the gene related to the 'featureClass', e.g. 'the 5 prime UTR upstream of TP53'",
+          "description": "Where applicable, ID/accession/name of genomic feature related to the `featureClass`. Preferably in CURIE format. If the value is a gene id or name, it points to the gene related to the `featureClass`, e.g. `the 5 prime UTR upstream of TP53`",
           "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
           "examples": [{ "id": "HGNC:11998", "label": "TP53" }]
         }
@@ -282,7 +282,7 @@
       "properties": {
         "population": {
           "type": "string",
-          "description": "A name for the population. A population could an ethnic, geographical one or just the 'members`of a study.",
+          "description": "A name for the population. A population could an ethnic, geographical one or just the `members`of a study.",
           "examples": [
             "East Asian",
             "ICGC Chronic Lymphocytic Leukemia-ES",

--- a/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "variantInternalId": {
-      "description": "Reference to the variant ID (internal ID). This is no a public Id, but the `primary key/identifier` of that variant inside a given Beacon instance. Therefore, different Beacon instances could have a variantInternalId = 1 and they could refer to completely unrelated variants. The public, standard, popular identifiers or the GA4GH Variant Representation Id (VRSid) MUST be returned in the  `identifiers` section. A Beacon instance can, of course, use the VRSid as their own internal id, in such case, the VRSid would be repeated in both places.",
+      "description": "Reference to the variant ID (internal ID). This is no a public Id, but the 'primary key/identifier' of that variant inside a given Beacon instance. Therefore, different Beacon instances could have a variantInternalId = 1 and they could refer to completely unrelated variants. The public, standard, popular identifiers or the GA4GH Variant Representation Id (VRSid) MUST be returned in the  `identifiers` section. A Beacon instance can, of course, use the VRSid as their own internal id, in such case, the VRSid would be repeated in both places.",
       "type": "string"
     },
     "variantType": {


### PR DESCRIPTION
This are some small changes in the variations schema description, including typo/formatting fixes & some streamlining.

TODO: We have a lot of originally nice Markdown formatting in some descriptions, which works well in YAML (even w/o conversion; one of Gruber's reason for creating Markdown...) but completely get jumbled in JSON. I really would prefer to switch to YAML as the way of writing JSON. If definitely not -> cleaning this everywhere (but this loses a lot of readability).