### PR TITLE
getting rid of non-standard `variantInternalId`

### DIFF
--- a/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
@@ -5,7 +5,7 @@
   "description": "Schema for a genomic variant entry.",
   "type": "object",
   "required": [
-    "variantInternalId",
+    "id",
     "variantType",
     "alternateBases",
     "position"

--- a/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "id": {
-      "description": "The internal id of the variant. This is not supposed to be used for a public id, but ratehr as the 'primary key/identifier' of that variant inside a given Beacon instance. Therefore, e,g, `'id': 'var1'` could refer to completely unrelated variants in different resources. The public, standard, popular identifiers or the GA4GH Variant Representation Id (VRSid) MUST be returned in the 'identifiers' section. A Beacon instance can, of course, use the VRSid as their own internal id, in such case, the VRSid would be repeated in both places.",
+      "description": "The internal id of the variant. This is not supposed to be used for a public id, but rather as the 'primary key/identifier' of that variant inside a given Beacon instance. Therefore, e,g, `'id': 'var1'` could refer to completely unrelated variants in different resources. The public, standard, popular identifiers or the GA4GH Variant Representation Id (VRSid) MUST be returned in the 'identifiers' section. A Beacon instance can, of course, use the VRSid as their own internal id, in such case, the VRSid would be repeated in both places.",
       "type": "string"
     },
     "variantType": {

--- a/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
@@ -11,8 +11,8 @@
     "position"
   ],
   "properties": {
-    "variantInternalId": {
-      "description": "Reference to the variant ID (internal ID). This is no a public Id, but the 'primary key/identifier' of that variant inside a given Beacon instance. Therefore, different Beacon instances could have a variantInternalId = 1 and they could refer to completely unrelated variants. The public, standard, popular identifiers or the GA4GH Variant Representation Id (VRSid) MUST be returned in the  'identifiers' section. A Beacon instance can, of course, use the VRSid as their own internal id, in such case, the VRSid would be repeated in both places.",
+    "id": {
+      "description": "The internal id of the variant. This is not supposed to be used for a public id, but ratehr as the 'primary key/identifier' of that variant inside a given Beacon instance. Therefore, e,g, `'id': 'var1'` could refer to completely unrelated variants in different resources. The public, standard, popular identifiers or the GA4GH Variant Representation Id (VRSid) MUST be returned in the 'identifiers' section. A Beacon instance can, of course, use the VRSid as their own internal id, in such case, the VRSid would be repeated in both places.",
       "type": "string"
     },
     "variantType": {

--- a/BEACON-V2-draft4-Model/genomicVariations/examples/genomicVariant-MID-example.json
+++ b/BEACON-V2-draft4-Model/genomicVariations/examples/genomicVariant-MID-example.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../defaultSchema.json",
-  "variantInternalId": "var123",
+  "id": "var123",
   "variantType": "SNP",
   "referenceBases": "G",
   "alternateBases": "A",

--- a/BEACON-V2-draft4-Model/genomicVariations/examples/genomicVariant-MIN-example.json
+++ b/BEACON-V2-draft4-Model/genomicVariations/examples/genomicVariant-MIN-example.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../defaultSchema.json",
-  "variantInternalId": "GRCh37-1-55505652-G-A",
+  "id": "GRCh37-1-55505652-G-A",
   "variantType": "SNP",
   "alternateBases": "A",
   "position": {


### PR DESCRIPTION
The use of a differently named `variantInternalId` instead of the standard `id` is against common use where the internal/proivate `id` can be addressed consistently for a given object (e.g. `variantInSample.id` instead of `variantInSample.variantyInternalId`).