### PR TITLE
frequencyInPopulations as child of variantLevelData

### DIFF
--- a/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
@@ -49,12 +49,6 @@
     },
     "variantLevelData": {
       "$ref": "#/definitions/VariantLevelData"
-    },
-    "frequencyInPopulations": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/FreqInPops"
-      }
     }
   },
   "definitions": {
@@ -364,7 +358,13 @@
         "items": {
           "$ref": "#/definitions/PhenoClinicEffect"
         }
-      }
+      },
+      "frequencyInPopulations": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/FreqInPops"
+        }
+      }      
     },
     "SoftwareTool": {
       "type": "object",

--- a/BEACON-V2-draft4-Model/genomicVariations/examples/genomicVariant-MID-example.json
+++ b/BEACON-V2-draft4-Model/genomicVariations/examples/genomicVariant-MID-example.json
@@ -37,27 +37,27 @@
         "effect":  { "id": "MONDO:0011369", "label": "hypercholesterolemia, autosomal dominant, 3" },
         "clinicalRelevance": "uncertain significance"
       }
+    ],
+    "frequencyInPopulations": [
+      {
+        "source":"gnomaD Genomes",
+        "sourceReference":"https://gnomad.broadinstitute.org/",
+        "version":"v3.1.1",
+        "frequencies": [
+          {"population": "European (non-Finish)", "alleleFrequency":	0.00002939 },
+          {"population": "Other", "alleleFrequency": 0.00 }
+        ]
+      },
+      {
+        "source":"ALFA",
+        "sourceReference":"https://www.ncbi.nlm.nih.gov/snp/docs/gsr/alfa/",
+        "version":"20201027095038",
+        "frequencies": [
+          {"population": "Total", "alleleFrequency": 0.00009 },
+          {"population": "European", "alleleFrequency": 0.00006 },
+          {"population": "African", "alleleFrequency": 0.00 }
+        ]
+      }
     ]
-  },
-  "frequencyInPopulations": [
-    {
-      "source":"gnomaD Genomes",
-      "sourceReference":"https://gnomad.broadinstitute.org/",
-      "version":"v3.1.1",
-      "frequencies": [
-        {"population": "European (non-Finish)", "alleleFrequency":	0.00002939 },
-        {"population": "Other", "alleleFrequency": 0.00 }
-      ]
-    },
-    {
-      "source":"ALFA",
-      "sourceReference":"https://www.ncbi.nlm.nih.gov/snp/docs/gsr/alfa/",
-      "version":"20201027095038",
-      "frequencies": [
-        {"population": "Total", "alleleFrequency": 0.00009 },
-        {"population": "European", "alleleFrequency": 0.00006 },
-        {"population": "African", "alleleFrequency": 0.00 }
-      ]
-    }
-  ]
+  }
 }


### PR DESCRIPTION
As discussed in #46 , `frequencyInPopulations` should be part of the `variantLevelData`.