### PR TITLE
adjusting the "run" schema to more general use.

### DIFF
--- a/BEACON-V2-draft4-Model/runs/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/runs/defaultSchema.json
@@ -1,32 +1,33 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "title": "Sequencing run",
+  "title": "Experimental run",
   "$comment": "version: ga4gh-beacon-biosample-v2.0.0-draft.4",
-  "description": "Schema for a sequencing run.",
+  "description": "Schema for the experimental run (e.g. sequencing run, array processing...) leading to the raw data for the (computational) analysis.",
   "type": "object",
   "properties": {
     "id": {
-      "description": "Run reference ID (external accession or internal ID).",
+      "description": "Run ID.",
       "type": "string",
       "example": "SRR10903401"
     },
     "biosampleId": {
-      "description": "Reference to Biosample ID.",
+      "description": "Reference to the biosample ID.",
       "type": "string",
-      "example": "S0001"
+      "example": "008dafdd-a3d1-4801-8c0a-8714e2b58e48"
     },
     "individualId": {
-      "description": "Reference to Individual ID.",
+      "description": "Reference to the individual ID.",
       "type": "string",
-      "example": "P0001"
+      "example": "TCGA-AO-A0JJ"
     },
     "runDate": {
-      "description": "Date at which run was performed.",
+      "description": "Date at which the experiment was performed.",
       "type": "string",
-      "format": "date"
+      "format": "date",
+      "example
     },
     "librarySource": {
-      "description": "Ontology value for sequencing library source e.g \"genomic source\", \"transcriptomic source\"",
+      "description": "Ontology value for the source of the sequencing or hybridization library, e.g \"genomic source\", \"transcriptomic source\"",
       "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
       "examples": [
         { "id": "GENEPIO:0001966", "label": "genomic source" },
@@ -34,31 +35,32 @@
       ]
     },
     "librarySelection": {
-      "description": "Selection method for sequencing library preparation, e.g \"RANDOM\", \"RT-PCR\"",
+      "description": "Selection method for library preparation, e.g \"RANDOM\", \"RT-PCR\"",
       "type": "string",
       "example": ["RANDOM", "RT-PCR"]
     },
     "libraryStrategy": {
-      "description": "Sequencing library strategy, e.g. \"WGS\"",
+      "description": "Library strategy, e.g. \"WGS\"",
       "type": "string"
     },
     "libraryLayout": {
-      "description": "Ontology value for sequencing library layout e.g \"PAIRED\", \"SINGLE\" #todo add Ontology name?",
+      "description": "Ontology value for the library layout e.g \"PAIRED\", \"SINGLE\" #todo add Ontology name?",
       "type": "string",
       "enum": ["PAIRED", "SINGLE"],
       "example": "SINGLE"
     },
     "platform": {
-      "description": "Ontology value for sequencing technology, e.g. \"Illumina\", \"Oxford Nanopore\". It SHOULD be a subset of the platformModel and used only for query convenience, e.g. \"return everything sequenced with Illimuna\", where the specific model is not relevant",
+      "description": "General platform technology label. It SHOULD be a subset of the platformModel and used only for query convenience, e.g. \"return everything sequenced with Illimuna\", where the specific model is not relevant",
       "type": "string",
-      "examples": ["Illumina", "Oxford Nanopore"]
+      "examples": ["Illumina", "Oxford Nanopore", "Affymetrix"]
     },
     "platformModel": {
-      "description": "Ontology value for sequencing technology, e.g. \"Illumina HiSeq 3000\", \"Oxford Nanopore MinION\". Check if OBI:0400103-DNA sequencer descendants are appropriate and use them, if possible.",
+      "description": "Ontology value for experimental platform or methodology used. For sequencing platforms the use of \"OBI:0400103 - DNA sequencer\" is suggested.",
       "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
       "examples": [
         { "id": "OBI:0002048", "label": "Illumina HiSeq 3000" },
-        { "id": "OBI:0002750", "label": "Oxford Nanopore MinION" }
+        { "id": "OBI:0002750", "label": "Oxford Nanopore MinION" },
+        { "id": "EFO:0010938", "label": "large-insert clone DNA microarray" }
       ]
     },
     "info": {

--- a/BEACON-V2-draft4-Model/runs/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/runs/defaultSchema.json
@@ -46,8 +46,7 @@
     "libraryLayout": {
       "description": "Ontology value for the library layout e.g \"PAIRED\", \"SINGLE\" #todo add Ontology name?",
       "type": "string",
-      "enum": ["PAIRED", "SINGLE"],
-      "example": "SINGLE"
+      "enum": ["PAIRED", "SINGLE"]
     },
     "platform": {
       "description": "General platform technology label. It SHOULD be a subset of the platformModel and used only for query convenience, e.g. \"return everything sequenced with Illimuna\", where the specific model is not relevant",


### PR DESCRIPTION
The original version was very specific towards sequencing experiments, while the updated is mostly technology agnostic in its parameter descriptions. 

No parameters were changed.