### PR TITLE
Extending endpoints.json for all response types

### DIFF
--- a/BEACON-V2-draft4-Model/analyses/endpoints.json
+++ b/BEACON-V2-draft4-Model/analyses/endpoints.json
@@ -27,14 +27,7 @@
         "tags": ["GET Endpoints"],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconErrorResponse.json"
@@ -83,14 +76,7 @@
         "tags": ["GET Endpoints"],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -114,14 +100,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -145,15 +124,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -177,15 +148,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -196,6 +159,22 @@
     }
   },
   "components": {
+    "responses": {
+      "ResultsOKResponse": {
+        "description": "Successful operation.",
+        "content": {
+          "application/json": {
+            "schema":{
+              "oneOf": [
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconBooleanResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconCountResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json" }
+              ]
+            }
+          }
+        }
+      }
+    },
     "parameters": {
       "requestedSchema": {
         "name": "requestedSchema",

--- a/BEACON-V2-draft4-Model/biosamples/endpoints.json
+++ b/BEACON-V2-draft4-Model/biosamples/endpoints.json
@@ -27,14 +27,7 @@
         "tags": ["GET Endpoints"],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconErrorResponse.json"
@@ -57,14 +50,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -83,14 +69,7 @@
         "tags": ["GET Endpoints"],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -114,14 +93,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -145,15 +117,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -177,15 +141,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -209,15 +165,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -241,15 +189,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -324,6 +264,22 @@
     }
   },
   "components": {
+    "responses": {
+      "ResultsOKResponse": {
+        "description": "Successful operation.",
+        "content": {
+          "application/json": {
+            "schema":{
+              "oneOf": [
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconBooleanResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconCountResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json" }
+              ]
+            }
+          }
+        }
+      }
+    },
     "parameters": {
       "requestedSchema": {
         "name": "requestedSchema",

--- a/BEACON-V2-draft4-Model/cohorts/endpoints.json
+++ b/BEACON-V2-draft4-Model/cohorts/endpoints.json
@@ -35,14 +35,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/CollectionsResponse"
           },
           "default":{
             "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconErrorResponse.json"
@@ -65,15 +58,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/CollectionsResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -95,15 +80,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -127,15 +104,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -159,15 +128,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -191,15 +152,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -274,6 +227,36 @@
     }
   },
   "components": {
+    "responses": {
+      "ResultsOKResponse": {
+        "description": "Successful operation.",
+        "content": {
+          "application/json": {
+            "schema":{
+              "oneOf": [
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconBooleanResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconCountResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json" }
+              ]
+            }
+          }
+        }
+      },
+      "CollectionsResponse": {
+        "description": "Successful collection list operation.",
+        "content": {
+          "application/json": {
+            "schema":{
+              "oneOf": [
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconBooleanResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconCountResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconCollectionsResponse.json" }
+              ]
+            }
+          }
+        }
+      }
+    },
     "parameters": {
       "requestedSchema": {
         "name": "requestedSchema",

--- a/BEACON-V2-draft4-Model/datasets/endpoints.json
+++ b/BEACON-V2-draft4-Model/datasets/endpoints.json
@@ -35,14 +35,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/CollectionsResponse"
           },
           "default":{
             "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconErrorResponse.json"
@@ -65,15 +58,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/CollectionsResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -95,15 +80,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -127,15 +104,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -159,15 +128,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -191,15 +152,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -223,15 +176,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -255,15 +200,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -287,15 +224,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -319,15 +248,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -402,6 +323,36 @@
     }
   },
   "components": {
+    "responses": {
+      "ResultsOKResponse": {
+        "description": "Successful operation.",
+        "content": {
+          "application/json": {
+            "schema":{
+              "oneOf": [
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconBooleanResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconCountResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json" }
+              ]
+            }
+          }
+        }
+      },
+      "CollectionsResponse": {
+        "description": "Successful collection list operation.",
+        "content": {
+          "application/json": {
+            "schema":{
+              "oneOf": [
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconBooleanResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconCountResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconCollectionsResponse.json" }
+              ]
+            }
+          }
+        }
+      }
+    },
     "parameters": {
       "requestedSchema": {
         "name": "requestedSchema",

--- a/BEACON-V2-draft4-Model/endpoints.json
+++ b/BEACON-V2-draft4-Model/endpoints.json
@@ -91,18 +91,7 @@
               "application/json": {
                 "schema":{
                   "description": "Response of a request for information about a Beacon",
-                  "type": "object",
-                  "required": ["meta","response"],
-                  "properties": {
-                    "meta": {
-                      "description": "TBD",
-                      "$ref":"https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/sections/beaconInformationalResponseMeta.json"
-                    },
-                    "response": {
-                      "description": "TBD",
-                      "$ref":"https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/configuration/beaconConfigurationSchema.json"
-                    }
-                  }
+                  "$ref":"https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconConfigurationResponse.json"
                 }
               }
             }
@@ -129,18 +118,7 @@
               "application/json": {
                 "schema":{
                   "description": "Response of a request for information about a Beacon",
-                  "type": "object",
-                  "required": ["meta","response"],
-                  "properties": {
-                    "meta": {
-                      "description": "TBD",
-                      "$ref":"https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/sections/beaconInformationalResponseMeta.json"
-                    },
-                    "response": {
-                      "description": "TBD",
-                      "$ref":"https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/configuration/beaconConfigurationSchema.json#/definitions/EntryTypes"
-                    }
-                  }
+                  "$ref":"https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconEntryTypesResponse.json"
                 }
               }
             }
@@ -166,19 +144,8 @@
             "content": {
               "application/json": {
                 "schema":{
-                  "description": "Response of a request for the Beacon Map of endpoints",
-                  "type": "object",
-                  "required": ["meta","response"],
-                  "properties": {
-                    "meta": {
-                      "description": "TBD",
-                      "$ref":"https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/sections/beaconInformationalResponseMeta.json"
-                    },
-                    "response": {
-                      "description": "TBD",
-                      "$ref":"https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/configuration/beaconMapSchema.json"
-                    }
-                  }
+                  "description": "Response of a request for information about a Beacon",
+                  "$ref":"https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconMapResponse.json"
                 }
               }
             }
@@ -221,18 +188,7 @@
           "application/json": {
             "schema":{
               "description": "Response of a request for information about a Beacon",
-              "type": "object",
-              "required": ["meta","response"],
-              "properties": {
-                "meta": {
-                  "description": "TBD",
-                  "$ref":"https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/sections/beaconInformationalResponseMeta.json"
-                },
-                "response": {
-                  "description": "TBD",
-                  "$ref":"https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/sections/beaconInfoResults.json"
-                }
-              }
+              "$ref":"https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconInfoResponse.json"
             }
           }
         }

--- a/BEACON-V2-draft4-Model/genomicVariations/endpoints.json
+++ b/BEACON-V2-draft4-Model/genomicVariations/endpoints.json
@@ -30,14 +30,7 @@
         "tags": ["GET Endpoints"],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconErrorResponse.json"
@@ -60,14 +53,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -86,14 +72,7 @@
         "tags": ["GET Endpoints"],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -117,14 +96,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -148,15 +120,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -180,15 +144,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -212,15 +168,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -244,15 +192,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -263,6 +203,22 @@
     }
   },
   "components": {
+    "responses": {
+      "ResultsOKResponse": {
+        "description": "Successful operation.",
+        "content": {
+          "application/json": {
+            "schema":{
+              "oneOf": [
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconBooleanResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconCountResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json" }
+              ]
+            }
+          }
+        }
+      }
+    },
     "parameters": {
       "requestedSchema": {
         "name": "requestedSchema",

--- a/BEACON-V2-draft4-Model/individuals/endpoints.json
+++ b/BEACON-V2-draft4-Model/individuals/endpoints.json
@@ -27,14 +27,7 @@
         "tags": ["GET Endpoints"],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconErrorResponse.json"
@@ -57,14 +50,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -83,14 +69,7 @@
         "tags": ["GET Endpoints"],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -114,14 +93,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -145,15 +117,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -177,15 +141,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -209,15 +165,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -241,15 +189,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -324,6 +264,22 @@
     }
   },
   "components": {
+    "responses": {
+      "ResultsOKResponse": {
+        "description": "Successful operation.",
+        "content": {
+          "application/json": {
+            "schema":{
+              "oneOf": [
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconBooleanResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconCountResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json" }
+              ]
+            }
+          }
+        }
+      }
+    },
     "parameters": {
       "requestedSchema": {
         "name": "requestedSchema",

--- a/BEACON-V2-draft4-Model/runs/endpoints.json
+++ b/BEACON-V2-draft4-Model/runs/endpoints.json
@@ -27,14 +27,7 @@
         "tags": ["GET Endpoints"],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconErrorResponse.json"
@@ -57,14 +50,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -83,14 +69,7 @@
         "tags": ["GET Endpoints"],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -114,14 +93,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -145,15 +117,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -177,15 +141,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -209,15 +165,7 @@
         "tags": [ "GET Endpoints" ],
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -241,15 +189,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": 
-              {
-                "schema":{
-                  "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ResultsOKResponse"
           },
           "default": {
             "description": "An unsuccessful operation",
@@ -260,6 +200,22 @@
     }
   },
   "components": {
+    "responses": {
+      "ResultsOKResponse": {
+        "description": "Successful operation.",
+        "content": {
+          "application/json": {
+            "schema":{
+              "oneOf": [
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconBooleanResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconCountResponse.json" },
+                { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/responses/beaconResultsetsResponse.json" }
+              ]
+            }
+          }
+        }
+      }
+    },
     "parameters": {
       "requestedSchema": {
         "name": "requestedSchema",


### PR DESCRIPTION
This PR tries to solve inconsistencies in the OpenAPI definitions (all `endpoints.json` files), that are currently covering just the Resultset response, but doesn't include the boolean, count nor Collections responses.