### PR TITLE
adding runId & cleaning analysisId

### DIFF
--- a/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
@@ -308,15 +308,20 @@
           "type": "string"
         },
         "individualId": {
-          "description": "Reference to individual ID.",
+          "description": "Reference to individual ID (`individual.id`)",
           "type": "string"
         },
         "biosampleId": {
-          "description": "Reference to biosample ID.",
+          "description": "Reference to biosample ID (`biosample.id`)",
           "type": "string"
         },
         "analysisId": {
-          "description": "Reference to run (Run.runId)",
+          "description": "Reference to the bioinformatics analysis ID (`analysis.id`)",
+          "type": "string",
+          "example": "pgxcs-kftvldsu"
+        },
+        "runId": {
+          "description": "Reference to the experimental run ID (`run.id`)",
           "type": "string",
           "example": "SRR10903401"
         },


### PR DESCRIPTION
The previous version had some confusing description of the `analysisId` scope w/ reference to `run`.

This cleans the id descriptions and adds `runId`.

Adding `runId` is not strictly necessary in a complete data model since it can be retrieved from `analysis`; but similar to the `individualId` can serve as a shortcut.