### PR TITLE
Adding example files and examples as arrays

### DIFF
--- a/BEACON-V2-draft4-Model/analyses/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/analyses/defaultSchema.json
@@ -12,30 +12,33 @@
     "runId": {
       "description": "Run identifier (external accession or internal ID).",
       "type": "string",
-      "example": "SRR10903401"
+      "examples": ["SRR10903401"]
     },
     "biosampleId": {
       "description": "Reference to Biosample ID.",
       "type": "string",
-      "example": "S0001"
+      "examples": ["S0001"]
     },
     "individualId": {
       "description": "Reference to Individual ID.",
       "type": "string",
-      "example": "P0001"
+      "examples": ["P0001"]
     },
     "analysisDate": {
       "description": "Date at which analysis was performed.",
       "type": "string",
-      "format": "date"
+      "format": "date",
+      "examples": ["2021-10-17"]
     },
     "pipelineName": {
       "description": "Analysis pipeline and version if a standardized pipeline was used",
-      "type": "string"
+      "type": "string",
+      "examples": ["Pipeline-panel-0001-v1"]
     },
     "pipelineRef": {
       "description": "Link to Analysis pipeline resource",
-      "type": "string"
+      "type": "string",
+      "examples": ["https://doi.org/10.48511/workflowhub.workflow.111.1"]
     },
     "aligner": {
       "description": "Reference to mapping/alignment software",

--- a/BEACON-V2-draft4-Model/analyses/examples/analyses-MAX-example.json
+++ b/BEACON-V2-draft4-Model/analyses/examples/analyses-MAX-example.json
@@ -1,0 +1,12 @@
+{ 
+  "$schema": "../defaultSchema.json",
+  "id": "analyses-example-0001",
+  "runId": "SRR10903401",
+  "biosampleId": "S0001",
+  "individualId": "P0001",
+  "analysisDate": "2021-10-17",
+  "pipelineName": "Pipeline-panel-0001-v1",
+  "pipelineRef": "https://doi.org/10.48511/workflowhub.workflow.111.1",
+  "aligner": "bwa-0.7.8",
+  "variantCaller": "GATK4.0"
+}

--- a/BEACON-V2-draft4-Model/analyses/examples/analyses-MIN-example.json
+++ b/BEACON-V2-draft4-Model/analyses/examples/analyses-MIN-example.json
@@ -1,0 +1,6 @@
+{ 
+  "$schema": "../defaultSchema.json",
+  "id": "analyses-example-0001",
+  "analysisDate": "2021-10-17",
+  "pipelineName": "Pipeline-panel-0001-v1"
+}

--- a/BEACON-V2-draft4-Model/biosamples/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/biosamples/defaultSchema.json
@@ -8,17 +8,17 @@
     "id": {
       "description": "Biosample identifier (external accession or internal ID).",
       "type": "string",
-      "example": "S0001"
+      "examples": ["S0001"]
     },
     "individualId": {
       "description": "Reference to the individual from which that sample was obtained.",
       "type": "string",
-      "example": "P0001"
+      "examples": ["P0001"]
     },
     "notes": {
       "description": "Any relevant info about the biosample that does not fit into any other field in the schema.",
       "type": "string",
-      "example": "Some free text"
+      "examples": ["Some free text"]
     },
     "biosampleStatus": {
       "description": "Ontology value from Experimental Factor Ontology (EFO) Material Entity term (BFO:0000040). Classification of the sample in abnormal sample (EFO:0009655) or reference sample (EFO:0009654).",
@@ -36,7 +36,7 @@
       "description": "Date of biosample collection in ISO8601 format.",
       "type": "string",
       "format": "date",
-      "example": "2021-04-23"
+      "examples": ["2021-04-23"]
     },
     "collectionMoment": {
       "description": "Individual's or cell cullture age at the time of sample collection in the ISO8601 duration format `P[n]Y[n]M[n]DT[n]H[n]M[n]S`.",
@@ -134,10 +134,12 @@
     "sampleProcessing": {
       "description": "Status of how the specimen was processed,e.g. a child term of EFO:0009091.",
       "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
-      "example": {
-        "id": "EFO:0009129",
-        "label": "mechanical dissociation"
-      }      
+      "examples": [
+        {
+          "id": "EFO:0009129",
+          "label": "mechanical dissociation"
+        }
+      ]
     },
     "sampleStorage": {
       "description": "Status of how the specimen was stored.",

--- a/BEACON-V2-draft4-Model/cohorts/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/cohorts/defaultSchema.json
@@ -21,7 +21,8 @@
     },
     "cohortId": {
       "description": "Cohort identifier. For ´study-defined´ or ´beacon-defined´cohorts this field is set by the implementer. For ´user-defined´ this unique identifier could be generated upon the query that defined the cohort, but could be later edited by the user.",
-      "type": "string"
+      "type": "string",
+      "examples": ["cohort-T2D-2010"]
     },
     "cohortName": {
       "description": "Name of the cohort. For ´user-defined´ this field could be generated upon the query, e.g. a value that is a concatenationor some representation of the user query.",
@@ -72,7 +73,7 @@
           "description": "date of collection event/data point",
           "type": "string",
           "format": "datetime",
-          "examples": ["2018-10-1", "2019-04-23", "2020-09-11"]
+          "examples": ["2018-10-01T13:23:45Z", "2019-04-23T09:11:13Z", "2017-01-17T20:33:40Z"]
         },
         "eventTimeline": {
           "description": "Aggregated information of dates of visit/diagnostic/inclusion in study obtained from individual level info in database. Will coincide with collection event date for multi-time",
@@ -81,12 +82,14 @@
             "start": {
               "description": "earliest date of visit",
               "type": "string",
-              "format": "datetime"
+              "format": "datetime",
+              "examples": ["2018-10-01T13:23:45Z", "2019-04-23T09:11:13Z", "2017-01-17T20:33:40Z"]
             },
             "end": {
               "description": "latest date of visit",
               "type": "string",
-              "format": "datetime"
+              "format": "datetime",
+              "examples": ["2018-10-01T13:23:45Z", "2019-04-23T09:11:13Z", "2017-01-17T20:33:40Z"]
             }
           }
         },

--- a/BEACON-V2-draft4-Model/datasets/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/datasets/defaultSchema.json
@@ -6,15 +6,18 @@
   "properties": {
     "id": {
       "type": "string",
-      "description": "Unique identifier of the dataset"
+      "description": "Unique identifier of the dataset",
+      "examples": ["ds01010101"]
     },
     "name": {
       "type": "string",
-      "description": "Name of the dataset"
+      "description": "Name of the dataset",
+      "examples": ["Dataset with synthetic data"]
     },
     "description": {
       "type": "string",
-      "description": "Description of the dataset"
+      "description": "Description of the dataset",
+      "examples": ["This dataset provides examples of the actual data in this Beacon instance."]
     },
     "createDateTime": {
       "type": "string",
@@ -30,12 +33,13 @@
     },
     "version": {
       "type": "string",
-      "description": "Version of the dataset"
+      "description": "Version of the dataset",
+      "examples": ["v1.1"]
     },
     "externalUrl": {
       "type": "string",
       "description": "URL to an external system providing more dataset information (RFC 3986 format).",
-      "example": "http://example.org/wiki/Main_Page"
+      "examples": ["http://example.org/wiki/Main_Page"]
     },
     "info": {
       "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/beaconCommonComponents.json#/definitions/Info"
@@ -77,7 +81,7 @@
           "properties": {
             "version": {
               "type": "string",
-              "example": "17-07-2016"
+              "examples": ["17-07-2016"]
             },
             "modifiers": {
               "type": "array",
@@ -87,7 +91,7 @@
                     "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json"
                   },
                   {
-                    "example": [
+                    "examples": [
                       {
                         "id": "EFO:0001645"
                       },
@@ -102,7 +106,7 @@
           }
         }
       ],
-      "example": [
+      "examples": [
         {
           "id": "DUO:0000007",
           "label": "disease specific research",

--- a/BEACON-V2-draft4-Model/datasets/examples/dataset-MIN-example.json
+++ b/BEACON-V2-draft4-Model/datasets/examples/dataset-MIN-example.json
@@ -1,0 +1,5 @@
+{ 
+  "$schema": "../defaultSchema.json",
+  "id": "ds01010101",
+  "name": "Dataset with synthetic data"
+}

--- a/BEACON-V2-draft4-Model/datasets/examples/dataset-Max-example.json
+++ b/BEACON-V2-draft4-Model/datasets/examples/dataset-Max-example.json
@@ -1,0 +1,22 @@
+{ 
+  "$schema": "../defaultSchema.json",
+  "id": "ds01010101",
+  "name": "Dataset with synthetic data",
+  "description": "This dataset provides examples of the actual data in this Beacon instance.",
+  "createDateTime": "2017-01-17T20:33:40Z",
+  "updateDateTime": "2017-01-17T20:33:40Z",
+  "version": "v1.1",
+  "externalUrl": "http://example.org/wiki/Main_Page",
+  "dataUseConditions": {
+    "duoDataUse": [
+      {
+        "id": "DUO:0000007",
+        "label": "disease specific research",
+        "version": "17-07-2016",
+        "modifiers": [
+          {"id":"EFO:0001645", "label": "coronary artery disease"}
+        ]
+      }
+    ]
+  }
+}

--- a/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/genomicVariations/defaultSchema.json
@@ -13,11 +13,11 @@
   "properties": {
     "variantInternalId": {
       "description": "Reference to the **internal** variant ID. This represents the primary key/identifier of that variant **inside** a given Beacon instance. Different Beacon instances may use identical id values, referring to unrelated variants. Public identifiers such as the GA4GH Variant Representation Id (VRSid) MUST be returned in the `identifiers` section. A Beacon instance can, of course, use the VRSid as their own internal id but still MUST represent this then in the `identifiers` section.",
-      "type": "string"
+      "type": "string",
+      "examples": ["var00001", "v110112"]
     },
     "variantType": {
       "description": "The `variantType` declares the nature of the variation in relation to a reference. In a response, it is used to describe the variation. In a request, it is used to declare the type of event the Beacon client is looking for. If in queries variants can not be defined through a sequence of one or more bases (`precise` variants) it can be used standalone (i.e. without `alternateBases`) together with positional parameters. Examples here are e.g. queries for structural variants such as `DUP` (increased allelic count of material from the genomic region  between `start` and `end` positions without assumption about the placement of the additional sequence) or `DEL` (deletion of sequence following `start`). Either `alternateBases` or `variantType` is required, with the exception of range queries (single `start` and `end` parameters).",
-
       "type": "string",
       "examples": ["SNP", "DEL", "DUP", "BND"],
       "default": "SNP"
@@ -25,12 +25,14 @@
     "referenceBases": {
       "description": "Reference bases for this variant (starting from `start`). * Accepted values: IUPAC codes for nucleotides (e.g. `https://www.bioinformatics.org/sms/iupac.html`). N is a wildcard, that denotes the position of any base, and can be used as a standalone base of any type or within a partially known sequence. As example, a query of `ANNT` the Ns can take take any form of `[ACGT]` and will match `ANNT`, `ACNT`, `ACCT`, `ACGT` ... and so forth. * an *empty value* is used in the case of insertions with the maximally trimmed, inserted sequence being indicated in `AlternateBases`. NOTE: Many Beacon instances could not support UIPAC codes and it is not mandatory for them to do so. In such cases the use of [ACGTN] is mandated.",
       "type": "string",
-      "pattern": "^([ACGTUNRYSWKMBDHV\\-\\.]*)$"
+      "pattern": "^([ACGTUNRYSWKMBDHV\\-\\.]*)$",
+      "examples": ["A","T","N","","ACG"]
     },
     "alternateBases": {
       "description": "Alternate bases for this variant (starting from `start`). * Accepted values: IUPAC codes for nucleotides (e.g. `https://www.bioinformatics.org/sms/iupac.html`). N is a wildcard, that denotes the position of any base, and can beused as a standalone base of any type or within a partially knownsequence. As example, a query of `ANNT` the Ns can take take any form of[ACGT] and will match `ANNT`, `ACNT`, `ACCT`, `ACGT` ... and so forth.* an *empty value* is used in the case of deletions with the maximally trimmed, deleted sequence being indicated in `ReferenceBases`* Categorical variant queries, e.g. such *not* being represented through sequence & position, make use of the `variantType` parameter. * Either `alternateBases` or `variantType` is required.",
       "type": "string",
-      "pattern": "^([ACGTUNRYSWKMBDHV\\-\\.]*)$"
+      "pattern": "^([ACGTUNRYSWKMBDHV\\-\\.]*)$",
+      "examples": ["T","G","N","AG", ""]
     },
     "position": {
       "$ref": "#/definitions/Position"
@@ -66,12 +68,12 @@
         "assemblyId": {
           "description": "Genomic assembly accession and version as RefSqeq assembly accession (e.g. 'GCF_000001405.39') or a versioned assembly name or synonym such as UCSC Genome Browser assembly (e.g. 'hg38') or Genome Reference Consortium Human (e.g. 'GRCh38.p13') names.",
           "type": "string",
-          "example": ["GCF_000001405.39", "hg38", "GRCh38.p13"]
+          "examples": ["GCF_000001405.39", "hg38", "GRCh38.p13"]
         },
         "refseqId": {
           "description": "Reference sequence id for genomic reference sequence in which variant coordinates are given, e.g. 'NC_000009' for human chromosome 9. Preferably the RefSeqId, alternatively, names, synonymous or aliases e.g. 'Chr9' could be used.",
           "type": "string",
-          "example": ["NC_000009", "Chr9", "NC_012920.1"]
+          "examples": ["NC_000009", "Chr9", "NC_012920.1"]
         },
         "start": {
           "description": "Precise or fuzzy start coordinate position(s) of the genomic variation (0-based, inclusive).",
@@ -107,12 +109,14 @@
         "items": {
           "type": "string"
         },
-        "example": ["dbSNP:rs3975092470", "ClinGen:CA003410", "VCV000055583.1"]
+        "examples": [
+          ["dbSNP:rs3975092470", "ClinGen:CA003410", "VCV000055583.1"]
+        ]
       },
       "genomicHGVSId": {
         "description": "HGVSId descriptor.",
         "type": "string",
-        "example": "NC_000017.11:g.43057063G>A"
+        "examples": ["NC_000017.11:g.43057063G>A"]
       },
       "transcriptHGVSIds": {
         "description": "List of HGVSId descriptor(s) at transcript level.",
@@ -120,7 +124,9 @@
         "items": {
           "type": "string"
         },
-        "example": ["NC 000023.10(NM004006.2):c.357+1G"]
+        "examples": [
+          ["NC 000023.10(NM004006.2):c.357+1G"]
+        ]
       },
       "proteinHGVSIds": {
         "description": "List of HGVSId descriptor(s) at protein level (for protein-altering variants).",
@@ -128,9 +134,9 @@
         "items": {
           "type": "string"
         },
-        "example": [
-          "NP_009225.1:p.Glu1817Ter",
-          "LRG 199p1:p.Val25Gly (preferred)"
+        "examples": [
+          ["NP_009225.1:p.Glu1817Ter"], 
+          ["LRG 199p1:p.Val25Gly (preferred)"]
         ]
       },
       "clinVarIds": {
@@ -141,7 +147,10 @@
     "MolecularAttributes": {
       "geneIds": {
         "type": "array",
-        "items": "string"
+        "items": "string",
+        "examples": [
+          ["ACE2"], ["BRCA1"]
+        ]
       },
       "genomicFeatures": {
         "description": "List of Genomic feature(s) affected by the variant.",
@@ -167,7 +176,9 @@
         "items": {
           "type": "string"
         },
-        "example": ["V304*"]
+        "examples": [
+          ["V304*"]
+        ]
       }
     },
     "GenomicFeature": {
@@ -305,25 +316,28 @@
       "properties": {
         "id": {
           "description": "Internal id of this case level *instance* of the variant. This is an optional housekeeping parameter and should not be confused with the identifier of the variant (`variantInternalId`).",
-          "type": "string"
+          "type": "string",
+          "examples": ["id0001-var101101118"]
         },
         "individualId": {
           "description": "Reference to individual ID (`individual.id`)",
-          "type": "string"
+          "type": "string",
+          "examples": ["ind0001"]
         },
         "biosampleId": {
           "description": "Reference to biosample ID (`biosample.id`)",
-          "type": "string"
+          "type": "string",
+          "examples": ["bs001104"]
         },
         "analysisId": {
           "description": "Reference to the bioinformatics analysis ID (`analysis.id`)",
           "type": "string",
-          "example": "pgxcs-kftvldsu"
+          "examples": ["pgxcs-kftvldsu"]
         },
         "runId": {
           "description": "Reference to the experimental run ID (`run.id`)",
           "type": "string",
-          "example": "SRR10903401"
+          "examples": ["SRR10903401"]
         },
         "zygosity": {
           "description": "Ontology term for zygosity in which variant is present in the sample from the Zygosity Ontology (GENO:0000391) , e.g `heterozygous` (GENO:0000135)",
@@ -382,12 +396,12 @@
         "toolName": {
           "description": "Name of the tool.",
           "type": "string",
-          "example": "Ensembl Variant Effect Predictor (VEP)"
+          "examples": ["Ensembl Variant Effect Predictor (VEP)"]
         },
         "version": {
           "description": "Version used.",
           "type": "string",
-          "example": "rel 104"
+          "examples": ["rel 104"]
         },
         "toolReferences": {
           "description": "References to the tool",

--- a/BEACON-V2-draft4-Model/runs/defaultSchema.json
+++ b/BEACON-V2-draft4-Model/runs/defaultSchema.json
@@ -8,22 +8,23 @@
     "id": {
       "description": "Run ID.",
       "type": "string",
-      "example": "SRR10903401"
+      "examples": ["SRR10903401"]
     },
     "biosampleId": {
       "description": "Reference to the biosample ID.",
       "type": "string",
-      "example": "008dafdd-a3d1-4801-8c0a-8714e2b58e48"
+      "examples": ["008dafdd-a3d1-4801-8c0a-8714e2b58e48"]
     },
     "individualId": {
       "description": "Reference to the individual ID.",
       "type": "string",
-      "example": "TCGA-AO-A0JJ"
+      "examples": ["TCGA-AO-A0JJ"]
     },
     "runDate": {
       "description": "Date at which the experiment was performed.",
       "type": "string",
-      "format": "date"
+      "format": "date",
+      "examples": ["2021-10-18"]
     },
     "librarySource": {
       "description": "Ontology value for the source of the sequencing or hybridization library, e.g \"genomic source\", \"transcriptomic source\"",
@@ -36,11 +37,12 @@
     "librarySelection": {
       "description": "Selection method for library preparation, e.g \"RANDOM\", \"RT-PCR\"",
       "type": "string",
-      "example": ["RANDOM", "RT-PCR"]
+      "examples": ["RANDOM", "RT-PCR"]
     },
     "libraryStrategy": {
       "description": "Library strategy, e.g. \"WGS\"",
-      "type": "string"
+      "type": "string",
+      "examples": ["WGS"]
     },
     "libraryLayout": {
       "description": "Ontology value for the library layout e.g \"PAIRED\", \"SINGLE\" #todo add Ontology name?",

--- a/BEACON-V2-draft4-Model/runs/examples/runs-MAX-example.json
+++ b/BEACON-V2-draft4-Model/runs/examples/runs-MAX-example.json
@@ -1,0 +1,19 @@
+{ 
+  "$schema": "../defaultSchema.json",
+  "id": "SRR10903401",
+  "biosampleId": "008dafdd-a3d1-4801-8c0a-8714e2b58e48",
+  "individualId": "TCGA-AO-A0JJ",
+  "runDate": "2021-10-18",
+  "librarySource": {
+    "id": "GENEPIO:0001966",
+    "label": "genomic source"
+  },
+  "librarySelection": "RANDOM",
+  "libraryStrategy": "WGS",
+  "libraryLayout": "PAIRED",
+  "platform": "Illumina",
+  "platformModel": {
+    "id": "OBI:0002048",
+    "label": "Illumina HiSeq 3000"
+  }
+}

--- a/BEACON-V2-draft4-Model/runs/examples/runs-MIN-example.json
+++ b/BEACON-V2-draft4-Model/runs/examples/runs-MIN-example.json
@@ -1,0 +1,6 @@
+{ 
+  "$schema": "../defaultSchema.json",
+  "id": "SRR10903401",
+  "biosampleId": "008dafdd-a3d1-4801-8c0a-8714e2b58e48",
+  "runDate": "2021-10-18"
+}


### PR DESCRIPTION
Missing examples are added (for analyses, datasets and runs).
Also all "example" properties in defaultSchema.json files have been converted into "examples" to facilitate picking the examples from JSON editors and other tools.