### PR TITLE
Making cohorts+datesets filtering terms compliant

### DIFF
--- a/BEACON-V2-draft4-Model/cohorts/filteringTerms.json
+++ b/BEACON-V2-draft4-Model/cohorts/filteringTerms.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/configuration/filteringTermsSchema.json",
   "filteringTerms": [
     {
+      "ftType": "ontologyTerm",
       "id": "DUO:0000006",
       "label": "health or medical or biomedical research",
       "version": "2021-02-23"

--- a/BEACON-V2-draft4-Model/datasets/filteringTerms.json
+++ b/BEACON-V2-draft4-Model/datasets/filteringTerms.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/configuration/filteringTermsSchema.json",
   "filteringTerms": [
     {
+      "ftType": "ontologyTerm",
       "id": "DUO:0000006",
       "label": "health or medical or biomedical research",
       "version": "2021-02-23"


### PR DESCRIPTION
I've corrected the filteringTerms.json of both Cohorts and Datasets as they are not compliant with the latest version of the schema in the configuration folder of the Framework.