### PR TITLE
changing "problematic" property names back to PXF version

### DIFF
--- a/BEACON-V2-draft4-Model/common/complexValue.json
+++ b/BEACON-V2-draft4-Model/common/complexValue.json
@@ -15,7 +15,7 @@
   "definitions": {
     "TypedQuantity": {
       "properties" : {
-        "quantityType" : {
+        "type" : {
           "description" : "OntologyClass to describe the type of the measurement. Renamed compared to GA4GH Phenopackets v2 `ComplexValue.TypedQuantity.type`",
           "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
           "example" : {

--- a/BEACON-V2-draft4-Model/common/externalReference.json
+++ b/BEACON-V2-draft4-Model/common/externalReference.json
@@ -14,7 +14,7 @@
       "type": "string",
       "example": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8155688/"
     },
-    "notes" : {
+    "description" : {
       "description": "An optional text descriptor. Renamed compared to GA4GH Phenopackets v2 `ExternalReference.description`",
       "type": "string",
       "example": "Signatures of Discriminative Copy Number Aberrations in 31 Cancer Subtypes"

--- a/BEACON-V2-draft4-Model/common/phenotypicFeature.json
+++ b/BEACON-V2-draft4-Model/common/phenotypicFeature.json
@@ -4,7 +4,7 @@
   "description": "Used to describe a phenotype that characterizes the subject or biosample.",
   "type": "object",
   "properties": {
-    "featureType": {
+    "type": {
       "description": "Term denoting the phenotypic feature, preferably using a value from Human Phenotype Ontology (HPO)",
       "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
       "examples": [

--- a/BEACON-V2-draft4-Model/common/procedure.json
+++ b/BEACON-V2-draft4-Model/common/procedure.json
@@ -4,7 +4,7 @@
   "description": "Class describing a clinical procedure or intervention. Provenance: GA4GH Phenopackets v2 `Procedure`",
   "type": "object",
   "properties": {
-    "procedureCode": {
+    "code": {
       "description": "Clinical procedure performed with recommended values from Medical Action Ontology (MAXO) 'Medical action' term tree (MAXO:0000001). Compares to Phenopackets v2 `Procedure.code`",
       "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
       "examples": [
@@ -27,10 +27,10 @@
       "format": "date",
       "example": "2010-07-10"
     },
-    "ageAtProcedure": {
+    "performed": {
       "description": "Compares to Phenopackets v2 `Procedure.performed`",
       "$ref": "./timeElement.json"
     }
   },
-  "required": ["procedureCode"]
+  "required": ["code"]
 }


### PR DESCRIPTION
In Beacon some parameters were renamed compared to the Phenopackets versions since they could be confused with JSON Schema keywords, e.g.

* `type`
* `description`

However, since these do not directly violate JSON Schema itself & with view to a better alignment we here may follow the original implementation.