### PR TITLE
fix ageOfOnset in disease

### DIFF
--- a/BEACON-V2-Model/common/disease.json
+++ b/BEACON-V2-Model/common/disease.json
@@ -14,7 +14,12 @@
       ]
     },
     "ageOfOnset": {
-      "$ref": "./age.json"
+      "$ref": "./timeElement.json",
+      "examples": [
+        { "ageGroup": { "id": "NCIT:C49685", "label": "Adult 18-65 Years Old" }, "age": "P32Y6M1D"},
+        { "ageRange": { "start": "P18Y", "end": "P59Y" } },
+        { "age": "P2M4D"}
+      ]
     },
     "stage": {
       "description": "Ontology term from Ontology for General Medical Science (OGMS), e.g. acute onset (OGMS:0000119). Provenance: GA4GH Phenopackets v2 `Disease.disease_stage`",


### PR DESCRIPTION
As discussed in https://github.com/ga4gh-beacon/beacon-v2-Models/issues/66, there was an erroneous definition of `ageOfOnset` with a simple reference to `Age`. Interestingly the examples were correct `¯\_(ツ)_/¯`.

This PR fixes it to the `timeElement`, as per Phenopackets use (though we'd renamed `ageOfOnset` from PXF `onset`, and `ageGroup` from PXF `ontology_group` before).