### PR TITLE
adjusting treatment and adding required schemas

### DIFF
--- a/BEACON-V2-Model/common/doseInterval.json
+++ b/BEACON-V2-Model/common/doseInterval.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DoseInterval",
+  "$comments": "From https://github.com/phenopackets/phenopacket-schema/blob/v2/docs/dose-interval.rst",
+  "description": "This element represents a block of time in which the dosage of a medication was constant. For example, to represent a period of 30 mg twice a day for an interval of 10 days, we would use a Quantity element to represent the individual 30 mg dose, and OntologyClass element to represent twice a day, and an Interval element to represent the 10-day interval. Provenance: Phenopackets v2",
+  "type": "object",
+  "properties": {
+    "quantity": {
+      "$ref": "./quantity.json"
+    },
+    "interval": {
+      "description": "The specific interval over which the dosage was administered in the indicated quantity.",
+      "$ref": "./timeInterval.json",
+      "examples": [ { "start": "1967-11-11T07:30:00+01", "end": "1967-11-18T12:00:00+01" } ]
+    },
+    "scheduleFrequency": {
+      "description": "How often doses are administered per day (or other indicated duration)",
+      "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
+      "examples": [ { "id": "NCIT:C64496", "label": "Twice Daily" } ]
+    }
+  },
+  "required": ["unit", "value"],
+  "additionalProperties": true
+}

--- a/BEACON-V2-Model/common/doseInterval.json
+++ b/BEACON-V2-Model/common/doseInterval.json
@@ -19,6 +19,6 @@
       "examples": [ { "id": "NCIT:C64496", "label": "Twice Daily" } ]
     }
   },
-  "required": ["unit", "value"],
-  "additionalProperties": true
+  "required": ["quantity", "interval", "scheduleFrequency"],
+  "additionalProperties": false
 }

--- a/BEACON-V2-Model/common/timeInterval.json
+++ b/BEACON-V2-Model/common/timeInterval.json
@@ -15,5 +15,7 @@
       "format": "date-time",
       "examples": [ "2022-03-10T15:25:07Z" ]
     }
-  }
+  },
+  "required": [ "start", "end" ],
+  "additionalProperties": false
 }

--- a/BEACON-V2-Model/common/timeInterval.json
+++ b/BEACON-V2-Model/common/timeInterval.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TimeInterval",
+  "description": "Time interval with start and end defined as ISO8601 time stamps.",
+  "type": "object",
+  "$comments": "From https://github.com/phenopackets/phenopacket-schema/blob/v2/docs/time-interval.rst",
+  "properties": {
+    "start": {
+      "type": "string",
+      "format": "date-time",
+      "examples": [ "1999-08-05T17:21:00+01:00", "2002-09-21T02:37:00-08:00"]
+    },
+    "end": {
+      "type": "string",
+      "format": "date-time",
+      "examples": [ "2022-03-10T15:25:07Z" ]
+    }
+  }
+}

--- a/BEACON-V2-Model/common/treatment.json
+++ b/BEACON-V2-Model/common/treatment.json
@@ -2,17 +2,18 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Treament",
   "description": "Treatment(s) prescribed/administered, defined by treatment ID, date and age of onset, dose, schedule and duration.",
+  "$comments": "Compares to https://github.com/phenopackets/phenopacket-schema/blob/master/docs/treatment.rst, with modifications.",
   "type": "object",
   "properties": {
     "treatmentCode": {
-      "description": "Code of treatment. Value from NCIT or any relevant ontology.",
+      "description": "Code of treatment. Value from NCIT or any relevant ontology. Compares to `agent` in Phenopackets v2",
       "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
       "examples": [
         { "id": "NCIT:C287", "label": "Aspirin" },
         { "id": "NCIT:C62078", "label": "Tamoxifen" }
       ]
     },
-    "route": {
+    "routeOfAdministration": {
       "description": "Route of treatment. Value from NCIT Route of Administration tree (NCIT:C38114).",
       "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
       "examples": [
@@ -23,22 +24,14 @@
     "ageAtOnset": {
       "$ref": "./age.json"
     },
-    "dose": {
-      "description": "The amount of any substance administered over a specific period of time. [ NCIT:C15682 ] ",
-      "type": "number"
+    "doseIntervals": {
+      "type": "array",
+      "items": {
+        "$ref": "./doseInterval.json"
+      }
     },
-    "unit": {
-      "description": "Treatment dose units",
-      "$ref": "./commonDefinitions.json#/definitions/Unit"
-    },
-    "frequency": {
-      "description": "The number of times a substance is administered within a specific time period. [ NCIT:C89081 ] ",
-      "type": "string"
-    },
-    "duration": {
-      "description": "Treatment duration in ISO8601 duration format",
-      "type": "string",
-      "example": "P7D"
+    "cumulativeDose": {
+      "$ref": "./quantity.json"
     }
   },
   "required": ["treatmentCode"],


### PR DESCRIPTION
This goes back to phenopackets alignment discussions and @pnrobinson 's comment in https://github.com/ga4gh-beacon/beacon-v2-Models/issues/83.

The major change here is to move the single dose / treatment schedule to `doseIntervals`.

The EHR-related case for an additional `drugType` enum seemed too special (but this could be added).