### PR TITLE
karyotypicSex first pass

### DIFF
--- a/BEACON-V2-Model/common/commonDefinitions.json
+++ b/BEACON-V2-Model/common/commonDefinitions.json
@@ -13,11 +13,11 @@
       ]
     },
     "KaryotypicSex": {
-      "description": "The chromosomal sex of an individual represented as ordinal values. The values correspond to: 0 - UNKNOWN_KARYOTYPE (Untyped or inconclusive karyotyping); 1 - XX (Female); 2 - XY (Male); 3 - XO (Single X chromosome only); 4 - XXY (Two X and one Y chromosome); 5 - XXX (Three X chromosomes); 6 - XXYY (Two X chromosomes and two Y chromosomes); 7 - XXXY (Three X chromosomes and one Y chromosome); 8 - XXXX (Four X chromosomes); 9 - XYY (One X and two Y chromosomes); 10 - OTHER_KARYOTYPE (None of the above types)",
+      "description": "The chromosomal sex of an individual represented from a selection of options. The values correspond to the ordinal values in the Phenopackets schema where: 0 - UNKNOWN_KARYOTYPE (Untyped or inconclusive karyotyping); 1 - XX (Female); 2 - XY (Male); 3 - XO (Single X chromosome only); 4 - XXY (Two X and one Y chromosome); 5 - XXX (Three X chromosomes); 6 - XXYY (Two X chromosomes and two Y chromosomes); 7 - XXXY (Three X chromosomes and one Y chromosome); 8 - XXXX (Four X chromosomes); 9 - XYY (One X and two Y chromosomes); 10 - OTHER_KARYOTYPE (None of the above types)",
       "$comments": "Compares to https://github.com/phenopackets/phenopacket-schema/blob/master/docs/karyotypicsex.rst",
       "type": "string",
-      "enum": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" ],
-      "default": "0"
+      "enum": ["UNKNOWN_KARYOTYPE", "XX", "XY", "XO", "XXY", "XXX", "XXYY", "XXXY", "XXXX", "XYY", "OTHER_KARYOTYPE" ],
+      "default": "UNKNOWN_KARYOTYPE"
     },
     "Ethnicity": {
       "description": "Ethnic background of the individual. Value from NCIT Race (NCIT:C17049) ontology term descendants, e.g. NCIT:C126531 (Latin American). A geographic ancestral origin category that is assigned to a population group based mainly on physical characteristics that are thought to be distinct and inherent. [ NCI ] ",

--- a/BEACON-V2-Model/common/commonDefinitions.json
+++ b/BEACON-V2-Model/common/commonDefinitions.json
@@ -12,6 +12,13 @@
         { "id": "NCIT:C1799", "label": "unknown" }
       ]
     },
+    "KaryotypicSex": {
+      "description": "The chromosomal sex of an individual represented as ordinal values. The values correspond to: 0 - UNKNOWN_KARYOTYPE (Untyped or inconclusive karyotyping); 1 - XX (Female); 2 - XY (Male); 3 - XO (Single X chromosome only); 4 - XXY (Two X and one Y chromosome); 5 - XXX (Three X chromosomes); 6 - XXYY (Two X chromosomes and two Y chromosomes); 7 - XXXY (Three X chromosomes and one Y chromosome); 8 - XXXX (Four X chromosomes); 9 - XYY (One X and two Y chromosomes); 10 - OTHER_KARYOTYPE (None of the above types)",
+      "$comments": "Compares to https://github.com/phenopackets/phenopacket-schema/blob/master/docs/karyotypicsex.rst",
+      "type": "integer",
+      "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+      "default": 0
+    },
     "Ethnicity": {
       "description": "Ethnic background of the individual. Value from NCIT Race (NCIT:C17049) ontology term descendants, e.g. NCIT:C126531 (Latin American). A geographic ancestral origin category that is assigned to a population group based mainly on physical characteristics that are thought to be distinct and inherent. [ NCI ] ",
       "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",

--- a/BEACON-V2-Model/common/commonDefinitions.json
+++ b/BEACON-V2-Model/common/commonDefinitions.json
@@ -15,9 +15,9 @@
     "KaryotypicSex": {
       "description": "The chromosomal sex of an individual represented as ordinal values. The values correspond to: 0 - UNKNOWN_KARYOTYPE (Untyped or inconclusive karyotyping); 1 - XX (Female); 2 - XY (Male); 3 - XO (Single X chromosome only); 4 - XXY (Two X and one Y chromosome); 5 - XXX (Three X chromosomes); 6 - XXYY (Two X chromosomes and two Y chromosomes); 7 - XXXY (Three X chromosomes and one Y chromosome); 8 - XXXX (Four X chromosomes); 9 - XYY (One X and two Y chromosomes); 10 - OTHER_KARYOTYPE (None of the above types)",
       "$comments": "Compares to https://github.com/phenopackets/phenopacket-schema/blob/master/docs/karyotypicsex.rst",
-      "type": "integer",
-      "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
-      "default": 0
+      "type": "string",
+      "enum": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" ],
+      "default": "0"
     },
     "Ethnicity": {
       "description": "Ethnic background of the individual. Value from NCIT Race (NCIT:C17049) ontology term descendants, e.g. NCIT:C126531 (Latin American). A geographic ancestral origin category that is assigned to a population group based mainly on physical characteristics that are thought to be distinct and inherent. [ NCI ] ",

--- a/BEACON-V2-Model/individuals/defaultSchema.json
+++ b/BEACON-V2-Model/individuals/defaultSchema.json
@@ -14,6 +14,10 @@
       "description": "Sex of the individual. Value from NCIT General Qualifier (NCIT:C27993): 'unknown' (not assessed or not available) (NCIT:C17998), 'female' (NCIT:C16576), or 'male', (NCIT:C20197).",
       "$ref": "../common/commonDefinitions.json#/definitions/Sex"
     },
+    "karyotypicSex": {
+      "description": "The chromosomal sex of an individual represented as ordinal values.",
+      "$ref": "../common/commonDefinitions.json#/definitions/KaryotypicSex"
+    },
     "ethnicity": {
       "description": "Ethnic background of the individual. Value from NCIT Race (NCIT:C17049) ontology term descendants, e.g. NCIT:C126531 (Latin American). A geographic ancestral origin category that is assigned to a population group based mainly on physical characteristics that are thought to be distinct and inherent. [ NCI ] ",
       "$ref": "../common/commonDefinitions.json#/definitions/Ethnicity"

--- a/BEACON-V2-Model/individuals/defaultSchema.json
+++ b/BEACON-V2-Model/individuals/defaultSchema.json
@@ -15,7 +15,7 @@
       "$ref": "../common/commonDefinitions.json#/definitions/Sex"
     },
     "karyotypicSex": {
-      "description": "The chromosomal sex of an individual represented as ordinal values.",
+      "description": "The chromosomal sex of an individual represented from a selection of options.",
       "$ref": "../common/commonDefinitions.json#/definitions/KaryotypicSex"
     },
     "ethnicity": {


### PR DESCRIPTION
This introduces the additional `karyotypicSex` attribute, as pointed out by @pnrobinson in https://github.com/ga4gh-beacon/beacon-v2-Models/issues/82. Please check ...