### PR TITLE
make unit a requirement in referenceRange

### DIFF
--- a/BEACON-V2-Model/common/referenceRange.json
+++ b/BEACON-V2-Model/common/referenceRange.json
@@ -20,6 +20,6 @@
       "examples": [135]
     }
   },
-  "required": ["low", "high"],
+  "required": ["unit", "low", "high"],
   "additionalProperties": true
 }

--- a/BEACON-V2-Model/common/referenceRange.json
+++ b/BEACON-V2-Model/common/referenceRange.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "unit": {
-      "description": "The kind of unit. RECOMMENDED.",
+      "description": "The kind of unit.",
       "$ref": "./commonDefinitions.json#/definitions/Unit",
       "examples": [{ "id": "NCIT:C49670", "label": "Millimeter of Mercury" }]
     },


### PR DESCRIPTION
As per https://github.com/ga4gh-beacon/beacon-v2-Models/issues/88, aligning w/ Phenopackets use.

(thanks @julesjacobsen)