### PR TITLE
renaming severityLevel to severity

### DIFF
--- a/BEACON-V2-Model/common/commonDefinitions.json
+++ b/BEACON-V2-Model/common/commonDefinitions.json
@@ -42,17 +42,6 @@
         { "id": "GAZ:00000460", "label": "Eurasia" }
       ]
     },
-    "SeverityLevel": {
-      "description": "Level/severity ontology when and as applicable to phenotype observed. Value from Human Phenotype Ontology (HP:0012824), e.g `mild`. The intensity or degree of a manifestation. [ HPO:probinson ] ",
-      "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
-      "examples": [
-        { "id": "HP:0012825", "label": "Severe" },
-        { "id": "HP:0012829", "label": "Profound" },
-        { "id": "HP:0012826", "label": "Moderate" },
-        { "id": "HP:0012825", "label": "Mild" },
-        { "id": "HP:0012827", "label": "Bordeline" }
-      ]
-    },
     "Unit": {
       "description": "The kind of unit. Recommended from NCIT Unit of Category ontology term (NCIT:C42568) descendants",
       "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",

--- a/BEACON-V2-Model/common/commonDefinitions.json
+++ b/BEACON-V2-Model/common/commonDefinitions.json
@@ -42,6 +42,17 @@
         { "id": "GAZ:00000460", "label": "Eurasia" }
       ]
     },
+    "SeverityLevel": {
+      "description": "Severity as applicable to phenotype or disease observed. Recommended are values from Human Phenotype Ontology (HP:0012824), e.g `mild`. The intensity or degree of a manifestation. Source: Phenopackets v2",
+      "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
+      "examples": [
+        { "id": "HP:0012828", "label": "Severe" },
+        { "id": "HP:0012829", "label": "Profound" },
+        { "id": "HP:0012826", "label": "Moderate" },
+        { "id": "HP:0012825", "label": "Mild" },
+        { "id": "HP:0012827", "label": "Borderline" }
+      ]
+    },
     "Unit": {
       "description": "The kind of unit. Recommended from NCIT Unit of Category ontology term (NCIT:C42568) descendants",
       "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",

--- a/BEACON-V2-Model/common/disease.json
+++ b/BEACON-V2-Model/common/disease.json
@@ -30,18 +30,22 @@
         { "id": "OGMS:0000106", "label": "remission" }
       ]
     },
-    "severityLevel": {
-      "$ref": "./commonDefinitions.json#/definitions/SeverityLevel"
+    "severity": {
+      "$ref": "./commonDefinitions.json#/definitions/SeverityLevel",
+      "examples": [
+        { "id": "HP:0012828", "label": "Severe" },
+        { "id": "HP:0012826", "label": "Moderate" }
+      ]
     },
     "familyHistory": {
       "description": "Boolean indicating determined or self-reported presence of family history of the disease.",
       "type": "boolean",
-      "example": true
+      "examples": [ true ]
     },
     "notes": {
       "description": "Unstructured text to describe additional properties of this disease instance.",
       "type": "string",
-      "example": "Some free text"
+      "examples": [ "Some free text" ]
     }
   },
   "required": ["diseaseCode"]

--- a/BEACON-V2-Model/common/phenotypicFeature.json
+++ b/BEACON-V2-Model/common/phenotypicFeature.json
@@ -42,14 +42,14 @@
       "$ref": "./evidence.json"
     },
     "severity": {
-      "description": "Level/severity ontology when and as applicable to phenotype observed. Suggested are values from Human Phenotype Ontology (HP:0012824). The intensity or degree of a manifestation. [ HPO:probinson ] ",
+      "description": "Level/severity ontology when and as applicable to phenotype observed. Suggested are values from Human Phenotype Ontology (HP:0012825). The intensity or degree of a manifestation. [ HPO:probinson ] ",
       "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
       "examples": [
-        { "id": "HP:0012825", "label": "Severe" },
+        { "id": "HP:0012828", "label": "Severe" },
         { "id": "HP:0012829", "label": "Profound" },
         { "id": "HP:0012826", "label": "Moderate" },
         { "id": "HP:0012825", "label": "Mild" },
-        { "id": "HP:0012827", "label": "Bordeline" }
+        { "id": "HP:0012827", "label": "Borderline" }
       ]
     },
     "notes": {

--- a/BEACON-V2-Model/common/phenotypicFeature.json
+++ b/BEACON-V2-Model/common/phenotypicFeature.json
@@ -42,14 +42,10 @@
       "$ref": "./evidence.json"
     },
     "severity": {
-      "description": "Level/severity ontology when and as applicable to phenotype observed. Suggested are values from Human Phenotype Ontology (HP:0012825). The intensity or degree of a manifestation. [ HPO:probinson ] ",
-      "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
+      "$ref": "./commonDefinitions.json#/definitions/SeverityLevel",
       "examples": [
         { "id": "HP:0012828", "label": "Severe" },
-        { "id": "HP:0012829", "label": "Profound" },
-        { "id": "HP:0012826", "label": "Moderate" },
-        { "id": "HP:0012825", "label": "Mild" },
-        { "id": "HP:0012827", "label": "Borderline" }
+        { "id": "HP:0012826", "label": "Moderate" }
       ]
     },
     "notes": {

--- a/BEACON-V2-Model/common/phenotypicFeature.json
+++ b/BEACON-V2-Model/common/phenotypicFeature.json
@@ -41,8 +41,16 @@
       "description": "The evidence for an assertion of the observation of a type. RECOMMENDED.",
       "$ref": "./evidence.json"
     },
-    "severityLevel": {
-      "$ref": "./commonDefinitions.json#/definitions/SeverityLevel"
+    "severity": {
+      "description": "Level/severity ontology when and as applicable to phenotype observed. Suggested are values from Human Phenotype Ontology (HP:0012824). The intensity or degree of a manifestation. [ HPO:probinson ] ",
+      "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
+      "examples": [
+        { "id": "HP:0012825", "label": "Severe" },
+        { "id": "HP:0012829", "label": "Profound" },
+        { "id": "HP:0012826", "label": "Moderate" },
+        { "id": "HP:0012825", "label": "Mild" },
+        { "id": "HP:0012827", "label": "Bordeline" }
+      ]
     },
     "notes": {
       "description": "Unstructured text to describe additional properties of this phenotypic feature.",

--- a/BEACON-V2-Model/individuals/examples/individual-MID-example.json
+++ b/BEACON-V2-Model/individuals/examples/individual-MID-example.json
@@ -26,7 +26,7 @@
         }
       },
       "familyHistory": false,
-      "severityLevel": {
+      "severity": {
         "id": "HP:0012829",
         "label": "Profound"
       },

--- a/BEACON-V2-Model/individuals/examples/individual-with-pedigree-MID-example.json
+++ b/BEACON-V2-Model/individuals/examples/individual-with-pedigree-MID-example.json
@@ -26,7 +26,7 @@
         }
       },
       "familyHistory": true,
-      "severityLevel": {
+      "severity": {
         "id": "HP:0012828",
         "label": "Severe"
       }


### PR DESCRIPTION
This removes the separate SeverityLevel definition in favour of a (renamed) `severity` as simple OntologyTerm.

Discussion in https://github.com/ga4gh-beacon/beacon-v2-Models/issues/91