### PR TITLE
TimeElement & Timestamp

### DIFF
--- a/BEACON-V2-Model/common/commonDefinitions.json
+++ b/BEACON-V2-Model/common/commonDefinitions.json
@@ -19,6 +19,12 @@
       "enum": ["UNKNOWN_KARYOTYPE", "XX", "XY", "XO", "XXY", "XXX", "XXYY", "XXXY", "XXXX", "XYY", "OTHER_KARYOTYPE" ],
       "default": "UNKNOWN_KARYOTYPE"
     },
+    "Timestamp": {
+      "description": "Time in date-time ISO8601 string format.",
+      "type": "string",
+      "format": "date-time",
+      "examples": [ "1999-08-05T17:21:00+01:00", "2002-09-21T02:37:00-08:00" ]
+    },
     "Ethnicity": {
       "description": "Ethnic background of the individual. Recommended is the use of a value from NCIT Race (NCIT:C17049) ontology term descendants, e.g. NCIT:C126531 (Latin American). A geographic ancestral origin category that is assigned to a population group based mainly on physical characteristics that are thought to be distinct and inherent. [ NCI ]",
       "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",

--- a/BEACON-V2-Model/common/timeElement.json
+++ b/BEACON-V2-Model/common/timeElement.json
@@ -1,35 +1,15 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "TimeElement",
-  "description": "Definition of a wrapper for various time descriptors.",
+  "description": "Definition of a wrapper for various time descriptors. This follows the Phenopackets structure https://github.com/phenopackets/phenopacket-schema/blob/v2/docs/time-element.rst",
   "type": "object",
-  "$comments": "TODO: Add other values from https://github.com/phenopackets/phenopacket-schema/blob/v2/docs/time-element.rst",
-  "properties": {
-    "age": {
-      "description": "Represents age as a ISO8601 duration (e.g., P40Y10M05D).",
-      "$ref": "./age.json",
-      "example": {"iso8601duration": "P32Y6M1D" }
-    },
-    "ageRange": {
-      "description": "Represents age as a ISO8601 duration (e.g., P40Y10M05D).",
-      "$ref": "./ageRange.json",
-      "example": {
-        "start": { "iso8601duration": "P18Y" },
-        "end": { "iso8601duration": "P59Y" }
-      }
-    },
-    "ageGroup": {
-      "description": "Indicates the age of the individual as an ontology class. Recommended from NCIT Age Group ontology term (NCIT:C20587) descendants.",
-      "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json",
-      "examples": [
-        { "id": "NCIT:C27954", "label": "Adolescent" },
-        { "id": "NCIT:C49685", "label": "Adult 18-65 Years Old" }
-      ]
-    },
-    "gestationalAge": {
-      "description": "Measure of the age of a pregnancy.",
-      "$ref": "./gestationalAge.json",
-      "examples": [ { "weeks": 33, "days": 2 } ]
-    }
-  }
+  "$comments": "If using an ontology class the use of NCIT Age Group ontology term (NCIT:C20587) descendants is recommended.",
+  "oneOf": [
+    { "$ref": "./age.json" },
+    { "$ref": "./ageRange.json" },
+    { "$ref": "./gestationalAge.json" },
+    { "$ref": "./commonDefinitions.json#/definitions/Timestamp" },
+    { "$ref": "./timeInterval.json" },
+    { "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json" }
+  ]
 }

--- a/BEACON-V2-Model/common/timeInterval.json
+++ b/BEACON-V2-Model/common/timeInterval.json
@@ -6,13 +6,11 @@
   "$comments": "From https://github.com/phenopackets/phenopacket-schema/blob/v2/docs/time-interval.rst",
   "properties": {
     "start": {
-      "type": "string",
-      "format": "date-time",
-      "examples": [ "1999-08-05T17:21:00+01:00", "2002-09-21T02:37:00-08:00"]
+      "$ref": "./commonDefinitions.json#/definitions/Timestamp",
+      "examples": [ "1999-08-05T17:21:00+01:00", "2002-09-21T02:37:00-08:00" ]
     },
     "end": {
-      "type": "string",
-      "format": "date-time",
+      "$ref": "./commonDefinitions.json#/definitions/Timestamp",
       "examples": [ "2022-03-10T15:25:07Z" ]
     }
   },

--- a/BEACON-V2-Model/datasets/defaultSchema.json
+++ b/BEACON-V2-Model/datasets/defaultSchema.json
@@ -20,16 +20,14 @@
       "examples": ["This dataset provides examples of the actual data in this Beacon instance."]
     },
     "createDateTime": {
-      "type": "string",
-      "format": "date-time",
+      "$ref": "../common/commonDefinitions.json#/definitions/Timestamp",
       "description": "The time the dataset was created (ISO 8601 format)",
-      "examples": ["2012-07-29", "2017-01-17T20:33:40Z"]
+      "examples": [ "2017-01-17T20:33:40Z" ]
     },
     "updateDateTime": {
-      "type": "string",
-      "format": "date-time",
+      "$ref": "../common/commonDefinitions.json#/definitions/Timestamp",
       "description": "The time the dataset was updated in (ISO 8601 format)",
-      "examples": ["2012-07-19", "2017-01-17T20:33:40Z"]
+      "examples": [ "2017-01-17T20:33:40Z" ]
     },
     "version": {
       "type": "string",


### PR DESCRIPTION
This commit introduces the Timestamp definition (in place of separately defining date-time strings) and also completes the Phenopackets changes for TimeElement. This is the basis for handling some of https://github.com/ga4gh-beacon/beacon-v2-Models/issues/92 

Please review for correct JSON etc.