### PR TITLE
dataUseConditions.json

### DIFF
--- a/BEACON-V2-Model/common/dataUseConditions.json
+++ b/BEACON-V2-Model/common/dataUseConditions.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Data Use Conditions",
+  "description": "Data use conditions",
+  "type": "object",
+  "properties": {
+    "duoDataUse": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DUODataUse"
+      },
+      "minItems": 1
+    }
+  },
+  "definitions": {
+    "DUODataUse": {
+      "allOf": [
+        {
+          "description": "Data Use Ontology codes nd additional information associated with a data object (e.g. sample, dataset)."
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json"
+        },
+        {
+          "type": "object",
+          "required": ["version"],
+          "properties": {
+            "version": {
+              "type": "string",
+              "examples": ["17-07-2016"]
+            },
+            "modifiers": {
+              "type": "array",
+              "items": {
+                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json"
+              },
+              "examples": [
+                {
+                  "id": "EFO:0001645",
+                  "label": "coronary artery disease"
+                },
+                {
+                  "id": "EFO:0001655"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "examples": [
+        {
+          "id": "DUO:0000007",
+          "label": "disease specific research",
+          "modifiers": [
+            { "id": "EFO:0001645", "label": "coronary artery disease" }
+          ],
+          "version": "17-07-2016"
+        },
+        {
+          "id": "DUO:0000004",
+          "label": "no restriction",
+          "version": "2022-03-23"
+        }
+      ]
+    }
+  },
+  "additionalProperties": true
+}

--- a/BEACON-V2-Model/common/dataUseConditions.json
+++ b/BEACON-V2-Model/common/dataUseConditions.json
@@ -16,7 +16,7 @@
     "DUODataUse": {
       "allOf": [
         {
-          "description": "Data Use Ontology codes nd additional information associated with a data object (e.g. sample, dataset)."
+          "description": "Data Use Ontology codes and additional information associated with a data object (e.g. sample, dataset)."
         },
         {
           "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json"

--- a/BEACON-V2-Model/datasets/defaultSchema.json
+++ b/BEACON-V2-Model/datasets/defaultSchema.json
@@ -45,76 +45,10 @@
       "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/beaconCommonComponents.json#/definitions/Info"
     },
     "dataUseConditions": {
-      "$ref": "#/definitions/DataUseConditions"
+      "description": "Data use conditions applying to this dataset.",
+      "$ref": "../common/dataUseConditions.json"
     }
   },
-
   "required": ["id", "name"],
-
-  "definitions": {
-    "DataUseConditions": {
-      "type": "object",
-      "description": "Data use conditions ruling this dataset",
-      "properties": {
-        "duoDataUse": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/DUODataUse"
-          },
-          "minItems": 1
-        }
-      },
-      "required": ["duoDataUse"]
-    },
-
-    "DUODataUse": {
-      "allOf": [
-        {
-          "description": "TBD"
-        },
-        {
-          "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json"
-        },
-        {
-          "type": "object",
-          "required": ["version"],
-          "properties": {
-            "version": {
-              "type": "string",
-              "examples": ["17-07-2016"]
-            },
-            "modifiers": {
-              "type": "array",
-              "items": {
-                "allOf": [
-                  {
-                    "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/ontologyTerm.json"
-                  },
-                  {
-                    "examples": [
-                      {
-                        "id": "EFO:0001645"
-                      },
-                      {
-                        "id": "EFO:0001655"
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          }
-        }
-      ],
-      "examples": [
-        {
-          "id": "DUO:0000007",
-          "label": "disease specific research",
-          "version": "17-07-2016"
-        }
-      ]
-    }
-  },
-
   "additionalProperties": true
 }

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ The GA4GH Beacon specification is composed by two parts:
 
 Additional information is now accessible through the [Beacon v2 Documentation](http://docs.genomebeacons.org/models/).
 
-**NOTE**: This is the project for Beacon v2 models development. The final Beacon v2 Farmework
+**NOTE**: This is the project for Beacon v2 models development. The final Beacon v2 Framework
 and Models will be made availble through the unified [`beacon-v2`](https://github.com/ga4gh-beacon/beacon-v2) repository.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # beacon-v2-Models
+
 Models that leverage the Beacon Framework v2
 
 ## Introduction
@@ -7,27 +8,9 @@ The GA4GH Beacon specification is composed by two parts:
 * the Beacon Framework
 * the Beacon Models
 
-The **Beacon Framework** (in [Framework repo](https://github.com/ga4gh-beacon/beacon-framework-v2) repo) is the part that describes the overall structure of the API requests, responses, parameters, the common components, etc. It could also be referred in this document as simply the *Framework*.
-
 **Beacon Models** (in *this* repo) describes the set of concepts included in a Beacon version (e.g. Beacon v2), like *individual* or *biosample*, and also the relationships between them. It could also be referred in this document as simply the *Model*.
 
-The Framework could be considered the *syntax* and the Model as the *semantics*. 
+Additional information is now accessible through the [Beacon v2 Documentation](http://docs.genomebeacons.org/models/).
 
-Refer to the [Framework repo](https://github.com/ga4gh-beacon/beacon-framework-v2) for further information about the Framework and its parts.
-
-A **Beacon instance** is just an implementation of a Beacon Model that follows the rules stated by the Beacon Framework.
-
-If you are a Beacon implementer, then, you don't need to clone the Framework repo, you only need to **copy** (*or clone*) the Beacon Model and modify it to your specific case. You will find plenty of references to the Framework in the Model copy, and you will use the Json schemas there to validate that both the structure of your requests and responses are compliant with the Beacon Framework. The Framewrok is not used to check the schema in the responses payload (e.g. the actual details of a biosample of a cohort). The schemas for that are included in the Model that you should have copied.
-
-The Model repo points to several Models and (temporarily) hosts the Model for Beacon v2:
-
-1. **The TEMPLATE Model:** [repo](https://github.com/ga4gh-beacon/Model-TEMPLATE) is the most basic model. Its purpose is twofold 1) as starting point for any *new* model (so to say, not Beacon v2) and 2) as a learning tool.
-2. **The Beacon v2 Model:** (in *this* repo) The complete Beacon v2 Model.
-3. **The Beacon v1 Model:** [repo](https://github.com/ga4gh-beacon/Model-BEACON-v1) Provided as an example for Beacon v1 implementers that want to update to Beacon v2 but not planning to add any additional entry type to their Beacon.
-
-### Coding and naming conventions
-For historical reasons, in the names of entities, parameters and URLs we are following the conventions:
-* Entity names: `PascalCase` 
-* parameters: `camelCase` 
-* URI path elements: `snake_case` 
-The only exception is: `service-info` which is a required GA4GH standard and has a different word separation convention.
+**NOTE**: This is the project for Beacon v2 models development. The final Beacon v2 Farmework
+and Models will be made availble through the unified [`beacon-v2`](https://github.com/ga4gh-beacon/beacon-v2) repository.


### PR DESCRIPTION
So far, "DataUseConditions" was defined inside the default schema for `datasets`. This PR moves the schema to a separate document and also fixes some odd nesting (remnant from older JSON Schema version).

Initiated by @redmitry comment https://github.com/ga4gh-beacon/beacon-v2-Models/issues/99