### PR TITLE
Removing cohort prefix on some attributes

### DIFF
--- a/BEACON-V2-Model/cohorts/defaultSchema.json
+++ b/BEACON-V2-Model/cohorts/defaultSchema.json
@@ -19,12 +19,12 @@
         { "id": "OMIABIS:0001024", "label": "twin study design" }
       ]
     },
-    "cohortId": {
+    "id": {
       "description": "Cohort identifier. For ´study-defined´ or ´beacon-defined´cohorts this field is set by the implementer. For ´user-defined´ this unique identifier could be generated upon the query that defined the cohort, but could be later edited by the user.",
       "type": "string",
       "examples": ["cohort-T2D-2010"]
     },
-    "cohortName": {
+    "name": {
       "description": "Name of the cohort. For ´user-defined´ this field could be generated upon the query, e.g. a value that is a concatenationor some representation of the user query.",
       "type": "string",
       "examples": [
@@ -32,12 +32,12 @@
         "GCAT Genomes for Life"
       ]
     },
-    "cohortInclusionCriteria": {
+    "inclusionCriteria": {
       "description": "Inclusion criteria used for defining the cohort. It is assumed that all cohort participants will match such criteria.",
       "type": "object",
       "$ref": "#/definitions/CohortCriteria"
     },
-    "cohortExclusionCriteria": {
+    "exclusionCriteria": {
       "description": "Exclusion criteria used for defining the cohort. It is assumed that NONE of the cohort participants will match such criteria.",
       "type": "object",
       "$ref": "#/definitions/CohortCriteria"
@@ -221,6 +221,6 @@
       "required": ["availability"]
     }
   },
-  "required": ["cohortId", "cohortName", "cohortType"],
+  "required": ["id", "name", "cohortType"],
   "additionalProperties": true
 }

--- a/BEACON-V2-Model/cohorts/examples/cohorts-MAX-example.json
+++ b/BEACON-V2-Model/cohorts/examples/cohorts-MAX-example.json
@@ -1,14 +1,14 @@
 {
   "$schema": "../defaultSchema.json",
-  "cohortId": "cohort0001",
-  "cohortName": "GCAT Genomes for Life",
+  "id": "cohort0001",
+  "name": "GCAT Genomes for Life",
   "cohortType": "study-defined",
   "cohortDesign": {
     "id": "OMIABIS:0001019",
     "label": "longitudinal study design"
   },
   "cohortSize": 20000,
-  "cohortInclusionCriteria": {
+  "inclusionCriteria": {
     "ageRange": {
       "start": { "iso8601duration": "P18Y" },
       "end": { "iso8601duration": "P40Y" }

--- a/BEACON-V2-Model/cohorts/examples/cohorts-MID-example.json
+++ b/BEACON-V2-Model/cohorts/examples/cohorts-MID-example.json
@@ -1,14 +1,14 @@
 {
   "$schema": "../defaultSchema.json",
-  "cohortId": "cohort0001",
-  "cohortName": "GCAT Genomes for Life",
+  "id": "cohort0001",
+  "name": "GCAT Genomes for Life",
   "cohortType": "study-defined",
   "cohortDesign": {
     "id": "OMIABIS:0001019",
     "label": "longitudinal study design"
   },
   "cohortSize": 20000,
-  "cohortInclusionCriteria": {
+  "inclusionCriteria": {
     "ageRange": {
       "start": { "iso8601duration": "P18Y" },
       "end": { "iso8601duration": "P40Y" }

--- a/BEACON-V2-Model/cohorts/examples/cohorts-MIN-example.json
+++ b/BEACON-V2-Model/cohorts/examples/cohorts-MIN-example.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../defaultSchema.json",
-  "cohortId": "cohort0001",
-  "cohortName": "GCAT Genomes for Life",
+  "id": "cohort0001",
+  "name": "GCAT Genomes for Life",
   "cohortType": "study-defined"
 }

--- a/changeLog.md
+++ b/changeLog.md
@@ -3,6 +3,17 @@ This document is planned as a manually maintained list of changes to the Beacon 
 It should only include changes that affect or could affect implementations, and the log would be updated *after* the corresponding pull request is approved and merged.
 This log only include the changes added after December, 1st 2021.
 
+### 2022-03-11/2022-03-25: removing 'cohort' prefix from some cohort properties [issue #102](https://github.com/ga4gh-beacon/beacon-v2-Models/issues/102) 
+
+Adapting the default schema for cohorts to the style used in property names for other entry types
+
+* `cohortId` to `id`
+* `cohortName` to `name`
+* `cohortInclusionCriteria` to `inclusionCriteria`
+* `cohortExclusionCriteria` to `exclusionCriteria`
+
+The properties that could be misleading if the prefix was removed like `type` or `size` are keeping the prefix.
+
 ### 2022-03-11/2022-03-14: More Phenopackets alignments [PR #84](https://github.com/ga4gh-beacon/beacon-v2-Models/pull/84) && [PR #85](https://github.com/ga4gh-beacon/beacon-v2-Models/pull/85) && [PR #86](https://github.com/ga4gh-beacon/beacon-v2-Models/pull/86) 
 
 This follows some discussions with Phenopackets developers (@pnrobinson & @julsejacobsen) and a general 


### PR DESCRIPTION
Adapting the default schema for cohorts to the style used in property names for other entry types

* `cohortId` to `id`
* `cohortName` to `name`
* `cohortInclusionCriteria` to `inclusionCriteria`
* `cohortExclusionCriteria` to `exclusionCriteria`

The properties that could be misleading if the prefix was removed like `type` or `size` are keeping the prefix.