### PR TITLE
adding genomicAlleleShortForm to requestParameters

### DIFF
--- a/BEACON-V2-Model/genomicVariations/requestParameters.json
+++ b/BEACON-V2-Model/genomicVariations/requestParameters.json
@@ -57,7 +57,7 @@
         "$ref": "./requestParametersComponents.json#/definitions/RefSeqId"
       },
       "geneId": {
-        "description": "Gene identifir, it is strongly suggested to use a symbol following the HGNC (https://www.genenames.org) nomenclature.",
+        "description": "Gene identifier, it is strongly suggested to use a symbol following the HGNC (https://www.genenames.org) nomenclature.",
         "type": "string",
         "examples": ["BRAF", "SCN5A"]
       },
@@ -65,6 +65,11 @@
         "description": "Aminoacid alteration of interest. Format 1 letter ",
         "type": "string",
         "examples": ["V600E", "M734V"]
+      },
+      "genomicAlleleShortForm": {
+        "description": "HGVSId descriptor",
+        "type": "string",
+        "examples": ["NM_004006.2:c.4375C>T"]
       }
     }
   }


### PR DESCRIPTION
The parameter exists in endpoints but not in the parameters schema.

As mentioned in https://github.com/ga4gh-beacon/beacon-v2-Models/pull/108