### PR TITLE
beacon@ga4gh.org => contact@genomebeacons.org in OpenAPI endpoints

### DIFF
--- a/BEACON-V2-Model/analyses/endpoints.json
+++ b/BEACON-V2-Model/analyses/endpoints.json
@@ -6,7 +6,7 @@
     "title": "GA4GH Beacon API Specification - Analysis endpoints",
     "description": "TBD",
     "contact": {
-      "email": "beacon@ga4gh.org"
+      "email": "contact@genomebeacons.org"
     },
     "license": {
       "name": "Apache 2.0",

--- a/BEACON-V2-Model/biosamples/endpoints.json
+++ b/BEACON-V2-Model/biosamples/endpoints.json
@@ -6,7 +6,7 @@
     "title": "GA4GH Beacon API Specification - Biosamples endpoints",
     "description": "TBD",
     "contact": {
-      "email": "beacon@ga4gh.org"
+      "email": "contact@genomebeacons.org"
     },
     "license": {
       "name": "Apache 2.0",

--- a/BEACON-V2-Model/cohorts/endpoints.json
+++ b/BEACON-V2-Model/cohorts/endpoints.json
@@ -6,7 +6,7 @@
     "title": "GA4GH Beacon API Specification - Cohorts Endpoints",
     "description": "TBD",
     "contact": {
-      "email": "beacon@ga4gh.org"
+      "email": "contact@genomebeacons.org"
     },
     "license": {
       "name": "Apache 2.0",

--- a/BEACON-V2-Model/datasets/endpoints.json
+++ b/BEACON-V2-Model/datasets/endpoints.json
@@ -6,7 +6,7 @@
     "title": "GA4GH Beacon API Specification - Datasets Endpoints",
     "description": "TBD",
     "contact": {
-      "email": "beacon@ga4gh.org"
+      "email": "contact@genomebeacons.org"
     },
     "license": {
       "name": "Apache 2.0",

--- a/BEACON-V2-Model/endpoints.json
+++ b/BEACON-V2-Model/endpoints.json
@@ -6,7 +6,7 @@
     "title": "GA4GH Beacon API Specification",
     "description": "A Beacon is a web service for data discovery and sharing that can be queried for information about entry types defined by a Model.",
     "contact": {
-      "email": "beacon@ga4gh.org"
+      "email": "contact@genomebeacons.org"
     },
     "license": {
       "name": "Apache 2.0",

--- a/BEACON-V2-Model/genomicVariations/endpoints.json
+++ b/BEACON-V2-Model/genomicVariations/endpoints.json
@@ -6,7 +6,7 @@
     "title": "GA4GH Beacon API Specification - Genomic Variations Endpoints",
     "description": "TBD",
     "contact": {
-      "email": "beacon@ga4gh.org"
+      "email": "contact@genomebeacons.org"
     },
     "license": {
       "name": "Apache 2.0",

--- a/BEACON-V2-Model/individuals/endpoints.json
+++ b/BEACON-V2-Model/individuals/endpoints.json
@@ -6,7 +6,7 @@
     "title": "GA4GH Beacon API Specification - Individuals Endpoints",
     "description": "TBD",
     "contact": {
-      "email": "beacon@ga4gh.org"
+      "email": "contact@genomebeacons.org"
     },
     "license": {
       "name": "Apache 2.0",

--- a/BEACON-V2-Model/runs/endpoints.json
+++ b/BEACON-V2-Model/runs/endpoints.json
@@ -6,7 +6,7 @@
     "title": "GA4GH Beacon API Specification - Runs Endpoints",
     "description": "TBD",
     "contact": {
-      "email": "beacon@ga4gh.org"
+      "email": "contact@genomebeacons.org"
     },
     "license": {
       "name": "Apache 2.0",


### PR DESCRIPTION
The email address beacon@ga4gh.org didn't exist.