### PR TITLE
filterIds in GET requests

### DIFF
--- a/BEACON-V2-Model/analyses/endpoints.json
+++ b/BEACON-V2-Model/analyses/endpoints.json
@@ -220,7 +220,7 @@
           "items": {
             "type": "string"
           },
-          "example": "variantcaller:GATK4.0"
+          "examples": [ [ "variantcaller:GATK4.0" ] ]
         }
       }
     }

--- a/BEACON-V2-Model/analyses/endpoints.json
+++ b/BEACON-V2-Model/analyses/endpoints.json
@@ -21,7 +21,7 @@
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
           { "$ref": "#/components/parameters/includeResultsetResponses" },
-          { "$ref": "#/components/parameters/filterIds" }
+          { "$ref": "#/components/parameters/filters" }
         ],
         "description": "Get a list of bioinformatics analysis",
         "operationId": "getAnalyses",
@@ -212,8 +212,8 @@
           "type": "string"
         }
       },
-      "filterIds": {
-        "name": "filterIds",
+      "filters": {
+        "name": "filters",
         "in": "query",
         "schema": {
           "type": "array",

--- a/BEACON-V2-Model/analyses/endpoints.json
+++ b/BEACON-V2-Model/analyses/endpoints.json
@@ -20,7 +20,8 @@
           { "$ref": "#/components/parameters/requestedSchema" },
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
-          { "$ref": "#/components/parameters/includeResultsetResponses" }
+          { "$ref": "#/components/parameters/includeResultsetResponses" },
+          { "$ref": "#/components/parameters/filterIds" }
         ],
         "description": "Get a list of bioinformatics analysis",
         "operationId": "getAnalyses",
@@ -209,6 +210,17 @@
         "required": true,
         "schema": {
           "type": "string"
+        }
+      },
+      "filterIds": {
+        "name": "filterIds",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": "variantcaller:GATK4.0"
         }
       }
     }

--- a/BEACON-V2-Model/biosamples/endpoints.json
+++ b/BEACON-V2-Model/biosamples/endpoints.json
@@ -21,7 +21,7 @@
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
           { "$ref": "#/components/parameters/includeResultsetResponses" },
-          { "$ref": "#/components/parameters/filterIds" }
+          { "$ref": "#/components/parameters/filters" }
         ],
         "description": "Get a list of biosamples",
         "operationId": "getBiosamples",
@@ -317,8 +317,8 @@
           "type": "string"
         }
       },
-      "filterIds": {
-        "name": "filterIds",
+      "filters": {
+        "name": "filters",
         "in": "query",
         "schema": {
           "type": "array",

--- a/BEACON-V2-Model/biosamples/endpoints.json
+++ b/BEACON-V2-Model/biosamples/endpoints.json
@@ -325,7 +325,7 @@
           "items": {
             "type": "string"
           },
-          "example": "NCIT:C3222"
+          "examples": [ [ "NCIT:C3222" ], [ "OBI:0100058", "NCIT:C4813" ] ]
         }
       }
     }

--- a/BEACON-V2-Model/biosamples/endpoints.json
+++ b/BEACON-V2-Model/biosamples/endpoints.json
@@ -20,7 +20,8 @@
           { "$ref": "#/components/parameters/requestedSchema" },
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
-          { "$ref": "#/components/parameters/includeResultsetResponses" }
+          { "$ref": "#/components/parameters/includeResultsetResponses" },
+          { "$ref": "#/components/parameters/filterIds" }
         ],
         "description": "Get a list of biosamples",
         "operationId": "getBiosamples",
@@ -314,6 +315,17 @@
         "required": true,
         "schema": {
           "type": "string"
+        }
+      },
+      "filterIds": {
+        "name": "filterIds",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": "NCIT:C3222"
         }
       }
     }

--- a/BEACON-V2-Model/cohorts/endpoints.json
+++ b/BEACON-V2-Model/cohorts/endpoints.json
@@ -29,7 +29,7 @@
           { "$ref":"#/components/parameters/requestedSchema" },
           { "$ref":"#/components/parameters/skip" },
           { "$ref":"#/components/parameters/limit" },
-          { "$ref": "#/components/parameters/filterIds" }
+          { "$ref": "#/components/parameters/filters" }
         ],
         "description": "Get a list of cohorts",
         "operationId": "getCohorts",
@@ -291,8 +291,8 @@
           "type":"string"
         }
       },
-      "filterIds": {
-        "name": "filterIds",
+      "filters": {
+        "name": "filters",
         "in": "query",
         "schema": {
           "type": "array",

--- a/BEACON-V2-Model/cohorts/endpoints.json
+++ b/BEACON-V2-Model/cohorts/endpoints.json
@@ -299,7 +299,7 @@
           "items": {
             "type": "string"
           },
-          "example": "OMIABIS:0001017"
+          "examples": [ [ "OMIABIS:0001017" ] ]
         }
       }
     }

--- a/BEACON-V2-Model/cohorts/endpoints.json
+++ b/BEACON-V2-Model/cohorts/endpoints.json
@@ -28,7 +28,8 @@
         "parameters": [
           { "$ref":"#/components/parameters/requestedSchema" },
           { "$ref":"#/components/parameters/skip" },
-          { "$ref":"#/components/parameters/limit" }
+          { "$ref":"#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/filterIds" }
         ],
         "description": "Get a list of cohorts",
         "operationId": "getCohorts",
@@ -288,6 +289,17 @@
         "required": true,
         "schema":{
           "type":"string"
+        }
+      },
+      "filterIds": {
+        "name": "filterIds",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": "OMIABIS:0001017"
         }
       }
     }

--- a/BEACON-V2-Model/datasets/endpoints.json
+++ b/BEACON-V2-Model/datasets/endpoints.json
@@ -28,7 +28,8 @@
         "parameters": [
           { "$ref":"#/components/parameters/requestedSchema" },
           { "$ref":"#/components/parameters/skip" },
-          { "$ref":"#/components/parameters/limit" }
+          { "$ref":"#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/filterIds" }
         ],
         "description": "Get a list of datasets",
         "operationId": "getDatasets",
@@ -384,6 +385,17 @@
         "required": true,
         "schema":{
           "type":"string"
+        }
+      },
+      "filterIds": {
+        "name": "filterIds",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": "DUO:0000007"
         }
       }
     }

--- a/BEACON-V2-Model/datasets/endpoints.json
+++ b/BEACON-V2-Model/datasets/endpoints.json
@@ -395,7 +395,7 @@
           "items": {
             "type": "string"
           },
-          "example": "DUO:0000007"
+          "examples": [ "DUO:0000007" ]
         }
       }
     }

--- a/BEACON-V2-Model/datasets/endpoints.json
+++ b/BEACON-V2-Model/datasets/endpoints.json
@@ -29,7 +29,7 @@
           { "$ref":"#/components/parameters/requestedSchema" },
           { "$ref":"#/components/parameters/skip" },
           { "$ref":"#/components/parameters/limit" },
-          { "$ref": "#/components/parameters/filterIds" }
+          { "$ref": "#/components/parameters/filters" }
         ],
         "description": "Get a list of datasets",
         "operationId": "getDatasets",
@@ -387,8 +387,8 @@
           "type":"string"
         }
       },
-      "filterIds": {
-        "name": "filterIds",
+      "filters": {
+        "name": "filters",
         "in": "query",
         "schema": {
           "type": "array",

--- a/BEACON-V2-Model/genomicVariations/endpoints.json
+++ b/BEACON-V2-Model/genomicVariations/endpoints.json
@@ -370,7 +370,7 @@
           "items": {
             "type": "string"
           },
-          "example": "EFO:0009655"
+          "examples": [ ["EFO:0009655"], [ "NCIT:C48725", "NCIT:C28080" ] ]
         }
       }
     }

--- a/BEACON-V2-Model/genomicVariations/endpoints.json
+++ b/BEACON-V2-Model/genomicVariations/endpoints.json
@@ -32,7 +32,7 @@
           { "$ref": "#/components/parameters/genomicAlleleShortForm" },
           { "$ref": "#/components/parameters/geneId" },
           { "$ref": "#/components/parameters/aminoacidChange" },
-          { "$ref": "#/components/parameters/filterIds" }
+          { "$ref": "#/components/parameters/filters" }
         ],
         "description": "Get a list of example entries",
         "operationId": "getExampleEntries",
@@ -362,8 +362,8 @@
         },
         "example": "V600E"
       },
-      "filterIds": {
-        "name": "filterIds",
+      "filters": {
+        "name": "filters",
         "in": "query",
         "schema": {
           "type": "array",

--- a/BEACON-V2-Model/genomicVariations/endpoints.json
+++ b/BEACON-V2-Model/genomicVariations/endpoints.json
@@ -31,7 +31,8 @@
           { "$ref": "#/components/parameters/variantMaxLength" },
           { "$ref": "#/components/parameters/genomicAlleleShortForm" },
           { "$ref": "#/components/parameters/geneId" },
-          { "$ref": "#/components/parameters/aminoacidChange" }
+          { "$ref": "#/components/parameters/aminoacidChange" },
+          { "$ref": "#/components/parameters/filterIds" }
         ],
         "description": "Get a list of example entries",
         "operationId": "getExampleEntries",
@@ -360,6 +361,17 @@
           "type": "string"
         },
         "example": "V600E"
+      },
+      "filterIds": {
+        "name": "filterIds",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": "EFO:0009655"
+        }
       }
     }
   }

--- a/BEACON-V2-Model/individuals/endpoints.json
+++ b/BEACON-V2-Model/individuals/endpoints.json
@@ -21,7 +21,7 @@
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
           { "$ref": "#/components/parameters/includeResultsetResponses" },
-          { "$ref": "#/components/parameters/filterIds" }
+          { "$ref": "#/components/parameters/filters" }
         ],
         "description": "Get a list of individuals",
         "operationId": "getIndividuals",
@@ -314,8 +314,8 @@
           "type": "string"
         }
       },
-      "filterIds": {
-        "name": "filterIds",
+      "filters": {
+        "name": "filters",
         "in": "query",
         "schema": {
           "type": "array",

--- a/BEACON-V2-Model/individuals/endpoints.json
+++ b/BEACON-V2-Model/individuals/endpoints.json
@@ -322,7 +322,7 @@
           "items": {
             "type": "string"
           },
-          "example": "NCIT:C20197"
+          "examples": [ [ "NCIT:C20197" ] ]
         }
       }
     }

--- a/BEACON-V2-Model/individuals/endpoints.json
+++ b/BEACON-V2-Model/individuals/endpoints.json
@@ -20,7 +20,8 @@
           { "$ref": "#/components/parameters/requestedSchema" },
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
-          { "$ref": "#/components/parameters/includeResultsetResponses" }
+          { "$ref": "#/components/parameters/includeResultsetResponses" },
+          { "$ref": "#/components/parameters/filterIds" }
         ],
         "description": "Get a list of individuals",
         "operationId": "getIndividuals",
@@ -311,6 +312,17 @@
         "required": true,
         "schema": {
           "type": "string"
+        }
+      },
+      "filterIds": {
+        "name": "filterIds",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": "NCIT:C20197"
         }
       }
     }

--- a/BEACON-V2-Model/runs/endpoints.json
+++ b/BEACON-V2-Model/runs/endpoints.json
@@ -277,7 +277,7 @@
           "items": {
             "type": "string"
           },
-          "example": "OBI:0002048"
+          "examples": [ [ "OBI:0002048" ] ]
         }
       }
     }

--- a/BEACON-V2-Model/runs/endpoints.json
+++ b/BEACON-V2-Model/runs/endpoints.json
@@ -21,7 +21,7 @@
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
           { "$ref": "#/components/parameters/includeResultsetResponses" },
-          { "$ref": "#/components/parameters/filterIds" }
+          { "$ref": "#/components/parameters/filters" }
         ],
         "description": "Get a list of sequencing runs",
         "operationId": "getRuns",
@@ -269,8 +269,8 @@
           "type": "string"
         }
       },
-      "filterIds": {
-        "name": "filterIds",
+      "filters": {
+        "name": "filters",
         "in": "query",
         "schema": {
           "type": "array",

--- a/BEACON-V2-Model/runs/endpoints.json
+++ b/BEACON-V2-Model/runs/endpoints.json
@@ -20,7 +20,8 @@
           { "$ref": "#/components/parameters/requestedSchema" },
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
-          { "$ref": "#/components/parameters/includeResultsetResponses" }
+          { "$ref": "#/components/parameters/includeResultsetResponses" },
+          { "$ref": "#/components/parameters/filterIds" }
         ],
         "description": "Get a list of sequencing runs",
         "operationId": "getRuns",
@@ -266,6 +267,17 @@
         "required": true,
         "schema": {
           "type": "string"
+        }
+      },
+      "filterIds": {
+        "name": "filterIds",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": "OBI:0002048"
         }
       }
     }


### PR DESCRIPTION
So far the Beacon models do not contain an option to insert filters into GET requests. This PR adds the parameter `filterIds` to the endpoints. The naming reflects the use for the `id` values of the `filteringTerms` schema (but IMO perfectly fine to use `filters` as parameter).

This addition addresses the majority of `filteringTerms` use cases[^1] (while not addressing filter specific modifications such as per-filter descendant term yes/no).

[^1]: As example, Progenetix resource has used this format since early 2019 for all its interface & API interactions.