### PR TITLE
Adding minimal requestParameters schemas to all entry types

### DIFF
--- a/BEACON-V2-Model/analyses/requestParameters.json
+++ b/BEACON-V2-Model/analyses/requestParameters.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/requests/requestParameters.json",
+  "analysis": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "runId": {
+        "type": "string"
+      },
+      "biosampleId": {
+        "type": "string"
+      },
+      "individualId": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/BEACON-V2-Model/biosamples/endpoints.json
+++ b/BEACON-V2-Model/biosamples/endpoints.json
@@ -20,6 +20,8 @@
           { "$ref": "#/components/parameters/requestedSchema" },
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/ids" },
+          { "$ref": "#/components/parameters/individualIds" },
           { "$ref": "#/components/parameters/includeResultsetResponses" }
         ],
         "description": "Get a list of biosamples",
@@ -304,6 +306,26 @@
         "schema": {
           "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/beaconCommonComponents.json#/definitions/Limit"
         }
+      },
+      "ids": {
+        "name": "id",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+        },
+      },
+      "individualIds": {
+        "name": "individualId",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+        },
       },
       "includeResultsetResponses": {
         "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"

--- a/BEACON-V2-Model/biosamples/requestParameters.json
+++ b/BEACON-V2-Model/biosamples/requestParameters.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/requests/requestParameters.json",
+  "biosample": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "individualId": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/BEACON-V2-Model/biosamples/requestParameters.json
+++ b/BEACON-V2-Model/biosamples/requestParameters.json
@@ -3,12 +3,18 @@
   "biosample": {
     "type": "object",
     "properties": {
-      "id": {
-        "type": "string"
+      "ids": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
       },
-      "individualId": {
-        "type": "string"
-      }
+      "individualIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+      },
     }
   }
 }

--- a/BEACON-V2-Model/cohorts/requestParameters.json
+++ b/BEACON-V2-Model/cohorts/requestParameters.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/requests/requestParameters.json",
+  "cohort": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/BEACON-V2-Model/datasets/requestParameters.json
+++ b/BEACON-V2-Model/datasets/requestParameters.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/requests/requestParameters.json",
+  "dataset": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/BEACON-V2-Model/individuals/requestParameters.json
+++ b/BEACON-V2-Model/individuals/requestParameters.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/requests/requestParameters.json",
+  "individual": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/BEACON-V2-Model/runs/requestParameters.json
+++ b/BEACON-V2-Model/runs/requestParameters.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/requests/requestParameters.json",
+  "run": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "biosampleId": {
+        "type": "string"
+      },
+      "individualId": {
+        "type": "string"
+      }
+    }
+  }
+}


### PR DESCRIPTION
As discussed in https://github.com/ga4gh-beacon/beacon-v2-Models/issues/50 it seems cleaner to have requestParameters defined for all entry types which at the minimum should contain the `id` parameter.

This PR add the documents as well as parameters for each `id` value defined in the schema (e.g. for `biosample` this would be `id` and `individualId`).