### PR TITLE
added key value to genomicVariations.variation.oneOf vrs $ref

### DIFF
--- a/BEACON-V2-Model/genomicVariations/defaultSchema.json
+++ b/BEACON-V2-Model/genomicVariations/defaultSchema.json
@@ -11,9 +11,18 @@
   "properties": {
     "variation": {
       "oneOf": [
-        {"$ref": "https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/MolecularVariation" },
-        {"$ref": "https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/SystemicVariation" },
-        {"$ref": "#/definitions/LegacyVariation" }
+        {
+          "MolecularVariation":
+            {"$ref": "https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/MolecularVariation" }
+        },
+        {
+          "SystemicVariation":
+            {"$ref": "https://raw.githubusercontent.com/ga4gh/vrs/1.2/schema/vrs.json#/definitions/SystemicVariation" }
+        },
+        {
+          "LegacyVariation":
+            {"$ref": "#/definitions/LegacyVariation" }
+        }
       ]
     },
     "variantInternalId": {


### PR DESCRIPTION
I added a key to external $ref pointers in genomicVariations default schema. 
The key (e.g., "MolecularVariation" is needed when de-referencing $ref in order to keep track of the object's key.

