### PR TITLE
Add minimal request parameters

### DIFF
--- a/BEACON-V2-Model/analyses/endpoints.json
+++ b/BEACON-V2-Model/analyses/endpoints.json
@@ -17,6 +17,8 @@
     "/analyses": {
       "get": {
         "parameters": [
+          { "$ref": "#/components/parameters/ids" },
+          { "$ref": "#/components/parameters/datasetIds" },
           { "$ref": "#/components/parameters/requestedSchema" },
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
@@ -202,6 +204,26 @@
       },
       "includeResultsetResponses": {
         "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+      },
+      "ids": {
+        "name": "id",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "datasetIds": {
+        "name": "datasetId",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       },
       "entryId": {
         "name": "id",

--- a/BEACON-V2-Model/analyses/requestParameters.json
+++ b/BEACON-V2-Model/analyses/requestParameters.json
@@ -3,17 +3,17 @@
   "analysis": {
     "type": "object",
     "properties": {
-      "id": {
-        "type": "string"
+      "ids": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       },
-      "runId": {
-        "type": "string"
-      },
-      "biosampleId": {
-        "type": "string"
-      },
-      "individualId": {
-        "type": "string"
+      "datasetIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     }
   }

--- a/BEACON-V2-Model/analyses/requestParameters.json
+++ b/BEACON-V2-Model/analyses/requestParameters.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/requests/requestParameters.json",
+  "analysis": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "runId": {
+        "type": "string"
+      },
+      "biosampleId": {
+        "type": "string"
+      },
+      "individualId": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/BEACON-V2-Model/biosamples/endpoints.json
+++ b/BEACON-V2-Model/biosamples/endpoints.json
@@ -17,11 +17,11 @@
     "/biosamples": {
       "get": {
         "parameters": [
+          { "$ref": "#/components/parameters/ids" },
+          { "$ref": "#/components/parameters/datasetIds" },
           { "$ref": "#/components/parameters/requestedSchema" },
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
-          { "$ref": "#/components/parameters/ids" },
-          { "$ref": "#/components/parameters/individualIds" },
           { "$ref": "#/components/parameters/includeResultsetResponses" }
         ],
         "description": "Get a list of biosamples",
@@ -314,18 +314,18 @@
           "type": "array",
           "items": {
             "type": "string"
-          },
-        },
+          }
+        }
       },
-      "individualIds": {
-        "name": "individualId",
+      "datasetIds": {
+        "name": "datasetId",
         "in": "query",
         "schema": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-        },
+          }
+        }
       },
       "includeResultsetResponses": {
         "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"

--- a/BEACON-V2-Model/biosamples/endpoints.json
+++ b/BEACON-V2-Model/biosamples/endpoints.json
@@ -20,6 +20,8 @@
           { "$ref": "#/components/parameters/requestedSchema" },
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/ids" },
+          { "$ref": "#/components/parameters/individualIds" },
           { "$ref": "#/components/parameters/includeResultsetResponses" }
         ],
         "description": "Get a list of biosamples",
@@ -304,6 +306,26 @@
         "schema": {
           "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/beaconCommonComponents.json#/definitions/Limit"
         }
+      },
+      "ids": {
+        "name": "id",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+        },
+      },
+      "individualIds": {
+        "name": "individualId",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+        },
       },
       "includeResultsetResponses": {
         "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"

--- a/BEACON-V2-Model/biosamples/requestParameters.json
+++ b/BEACON-V2-Model/biosamples/requestParameters.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/requests/requestParameters.json",
+  "biosample": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "individualId": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/BEACON-V2-Model/biosamples/requestParameters.json
+++ b/BEACON-V2-Model/biosamples/requestParameters.json
@@ -7,14 +7,14 @@
         "type": "array",
         "items": {
           "type": "string"
-        },
+        }
       },
-      "individualIds": {
+      "datasetIds": {
         "type": "array",
         "items": {
           "type": "string"
-        },
-      },
+        }
+      }
     }
   }
 }

--- a/BEACON-V2-Model/biosamples/requestParameters.json
+++ b/BEACON-V2-Model/biosamples/requestParameters.json
@@ -3,12 +3,18 @@
   "biosample": {
     "type": "object",
     "properties": {
-      "id": {
-        "type": "string"
+      "ids": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
       },
-      "individualId": {
-        "type": "string"
-      }
+      "individualIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+      },
     }
   }
 }

--- a/BEACON-V2-Model/cohorts/endpoints.json
+++ b/BEACON-V2-Model/cohorts/endpoints.json
@@ -27,7 +27,6 @@
       "get": {
         "parameters": [
           { "$ref": "#/components/parameters/ids" },
-          { "$ref": "#/components/parameters/datasetIds" },
           { "$ref":"#/components/parameters/requestedSchema" },
           { "$ref":"#/components/parameters/skip" },
           { "$ref":"#/components/parameters/limit" }
@@ -286,16 +285,6 @@
       },
       "ids": {
         "name": "id",
-        "in": "query",
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "datasetIds": {
-        "name": "datasetId",
         "in": "query",
         "schema": {
           "type": "array",

--- a/BEACON-V2-Model/cohorts/endpoints.json
+++ b/BEACON-V2-Model/cohorts/endpoints.json
@@ -26,6 +26,8 @@
     "/cohorts": {
       "get": {
         "parameters": [
+          { "$ref": "#/components/parameters/ids" },
+          { "$ref": "#/components/parameters/datasetIds" },
           { "$ref":"#/components/parameters/requestedSchema" },
           { "$ref":"#/components/parameters/skip" },
           { "$ref":"#/components/parameters/limit" }
@@ -280,6 +282,26 @@
         "in": "query",
         "schema":{
           "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/beaconCommonComponents.json#/definitions/Limit"
+        }
+      },
+      "ids": {
+        "name": "id",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "datasetIds": {
+        "name": "datasetId",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "entryId": {

--- a/BEACON-V2-Model/cohorts/requestParameters.json
+++ b/BEACON-V2-Model/cohorts/requestParameters.json
@@ -3,8 +3,17 @@
   "cohort": {
     "type": "object",
     "properties": {
-      "id": {
-        "type": "string"
+      "ids": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "datasetIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     }
   }

--- a/BEACON-V2-Model/cohorts/requestParameters.json
+++ b/BEACON-V2-Model/cohorts/requestParameters.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/requests/requestParameters.json",
+  "cohort": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/BEACON-V2-Model/datasets/endpoints.json
+++ b/BEACON-V2-Model/datasets/endpoints.json
@@ -26,6 +26,7 @@
     "/datasets": {
       "get": {
         "parameters": [
+          { "$ref": "#/components/parameters/ids" },
           { "$ref":"#/components/parameters/requestedSchema" },
           { "$ref":"#/components/parameters/skip" },
           { "$ref":"#/components/parameters/limit" }
@@ -376,6 +377,16 @@
         "in": "query",
         "schema":{
           "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/beaconCommonComponents.json#/definitions/Limit"
+        }
+      },
+      "ids": {
+        "name": "id",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "entryId": {

--- a/BEACON-V2-Model/datasets/requestParameters.json
+++ b/BEACON-V2-Model/datasets/requestParameters.json
@@ -3,8 +3,11 @@
   "dataset": {
     "type": "object",
     "properties": {
-      "id": {
-        "type": "string"
+      "ids": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     }
   }

--- a/BEACON-V2-Model/datasets/requestParameters.json
+++ b/BEACON-V2-Model/datasets/requestParameters.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/requests/requestParameters.json",
+  "dataset": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/BEACON-V2-Model/genomicVariations/endpoints.json
+++ b/BEACON-V2-Model/genomicVariations/endpoints.json
@@ -21,6 +21,8 @@
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
           { "$ref": "#/components/parameters/includeResultsetResponses" },
+          { "$ref": "#/components/parameters/ids" },
+          { "$ref": "#/components/parameters/datasetIds" },
           { "$ref": "#/components/parameters/start" },
           { "$ref": "#/components/parameters/end" },
           { "$ref": "#/components/parameters/assemblyId" },
@@ -254,6 +256,26 @@
       },
       "includeResultsetResponses": {
         "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+      },
+      "ids": {
+        "name": "id",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "datasetIds": {
+        "name": "datasetId",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       },
       "entryId": {
         "name": "id",

--- a/BEACON-V2-Model/genomicVariations/requestParameters.json
+++ b/BEACON-V2-Model/genomicVariations/requestParameters.json
@@ -6,6 +6,18 @@
       "assemblyId": {
         "$ref": "./requestParametersComponents.json#/definitions/Assembly"
       },
+      "ids": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "datasetIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
       "referenceName": {
         "$ref": "./requestParametersComponents.json#/definitions/RefSeqId"
       },

--- a/BEACON-V2-Model/individuals/endpoints.json
+++ b/BEACON-V2-Model/individuals/endpoints.json
@@ -17,6 +17,8 @@
     "/individuals": {
       "get": {
         "parameters": [
+          { "$ref": "#/components/parameters/ids" },
+          { "$ref": "#/components/parameters/datasetIds" },
           { "$ref": "#/components/parameters/requestedSchema" },
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },
@@ -304,6 +306,26 @@
       },
       "includeResultsetResponses": {
         "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/common/beaconCommonComponents.json#/definitions/IncludeResultsetResponses"
+      },
+      "ids": {
+        "name": "id",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "datasetIds": {
+        "name": "datasetId",
+        "in": "query",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       },
       "entryId": {
         "name": "id",

--- a/BEACON-V2-Model/individuals/requestParameters.json
+++ b/BEACON-V2-Model/individuals/requestParameters.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/requests/requestParameters.json",
+  "individual": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/BEACON-V2-Model/individuals/requestParameters.json
+++ b/BEACON-V2-Model/individuals/requestParameters.json
@@ -3,8 +3,17 @@
   "individual": {
     "type": "object",
     "properties": {
-      "id": {
-        "type": "string"
+      "ids": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "datasetIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     }
   }

--- a/BEACON-V2-Model/runs/endpoints.json
+++ b/BEACON-V2-Model/runs/endpoints.json
@@ -17,6 +17,8 @@
     "/runs": {
       "get": {
         "parameters": [
+          { "$ref": "#/components/parameters/ids" },
+          { "$ref": "#/components/parameters/datasetIds" },
           { "$ref": "#/components/parameters/requestedSchema" },
           { "$ref": "#/components/parameters/skip" },
           { "$ref": "#/components/parameters/limit" },

--- a/BEACON-V2-Model/runs/requestParameters.json
+++ b/BEACON-V2-Model/runs/requestParameters.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-framework-v2/main/requests/requestParameters.json",
+  "run": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "biosampleId": {
+        "type": "string"
+      },
+      "individualId": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/BEACON-V2-Model/runs/requestParameters.json
+++ b/BEACON-V2-Model/runs/requestParameters.json
@@ -3,14 +3,17 @@
   "run": {
     "type": "object",
     "properties": {
-      "id": {
-        "type": "string"
+      "ids": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       },
-      "biosampleId": {
-        "type": "string"
-      },
-      "individualId": {
-        "type": "string"
+      "datasetIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     }
   }


### PR DESCRIPTION
... after some clarifications about avoiding REST collisions etc. now only adding ids (plural) and datasetIds as request parameters, and GET parameters for non-{id} paths.

See discussion https://github.com/ga4gh-beacon/beacon-v2/issues/24 & https://github.com/ga4gh-beacon/beacon-v2-Models/pull/112#issuecomment-1091232918 (ff).